### PR TITLE
Add colorProfile to Player and bug fixes.

### DIFF
--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -84,14 +84,13 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                     <Text>{`Total Number of Games: ${commander.matches.length}`}</Text>
                     <Text>{`Wins: ${commander.wins}`}</Text>
                     <Text>
-                        {`Winrate: ${
-                            commander.matches.length > 0
+                        {`Winrate: ${commander.matches.length > 0
                                 ? Math.round((commander.wins / commander.matches.length) * 100)
                                 : 0
-                        }%`}
+                            }%`}
                     </Text>
                     <Text>{`Qualified: ${matches.length >= COMMANDER_MINIMUM_GAMES_REQUIRED ? "Yes" : "No"}`}</Text>
-                    <Text>{`Color Identity: ${commander.color_identity}`}</Text>
+                    <Text>{`Color Identity: ${commander.colorIdentity}`}</Text>
                 </Flex>
             </Flex>
             <Tabs isFitted={true} width={"100%"} paddingRight={"10%"} paddingLeft={"10%"}>

--- a/src/components/matchHistory/MatchPlayerCard.tsx
+++ b/src/components/matchHistory/MatchPlayerCard.tsx
@@ -21,7 +21,7 @@ export const MatchPlayerCard = React.memo(function MatchPlayerCard
     const navigate = useNavigate();
 
     const playerNav = useCallback(() => {
-        navigate('/playerOverview/' + player.name.toLowerCase());
+        navigate('/playerOverview/' + player.name);
     }, [navigate, player.name]);
 
     return (

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -4,51 +4,59 @@ import { Match } from "../types/domain/Match";
 import { Player } from "../types/domain/Player";
 
 /**
- * Given a collection of matches and a player NAME, create a dictionary of commanders played by a player as identified by that specific playerId
+ * Given a collection of matches, create a dictionary of commanders with optional filters applied
  * @param matches The collection of matches to bulid the dictionary from
  * @param playerId The player name to filter commanders by
  * @returns A dictionary of commanders keyed by commanderId
  */
-export function getCommandersByPlayerNameHelper(matches: Match[], playerName: string): { [id: string]: Commander } {
+export function matchesToCommanderHelper(
+    matches: Match[],
+    playerNameFilter?: string
+): { [id: string]: Commander } {
     const playedCommanderDictionary: { [id: string]: Commander } = {};
     for (const currentMatch of matches) {
         // iterate through each player, and add those commanders to our commander dictionary
         for (const player of currentMatch.players) {
-            if (player.name === playerName) {
-                // there is a chance the commander is actually multiple commanders.
-                // the current separator for commanders is " && "
-                const currentCommanderNames: string[] = player.commanders;
 
-                // loop through all commanders and update our commanders dictionary
-                for (const currentCommanderName of currentCommanderNames) {
-                    const commander = commanderList[currentCommanderName];
+            // apply our filters
+            if (playerNameFilter !== undefined && player.name !== playerNameFilter) {
+                // we have an active playerName filter-- if the player name is not a match, then we skip it
+                continue;
+            }
 
-                    // check to see if the commander name is valid
-                    if (commander === undefined) {
-                        // log the invalid commander
-                        console.log(
-                            `Invalid commander found in currentMatch <${currentMatch.id}> : ${currentCommanderName}`,
-                        );
-                        continue;
-                    }
+            // there is a chance the commander is actually multiple commanders.
+            // the current separator for commanders is " && "
+            const currentCommanderNames: string[] = player.commanders;
 
-                    // commander name is valid. let's check to see if we already added it to our dictionary
-                    const potentialCommanderObj = playedCommanderDictionary[commander.id];
-                    if (potentialCommanderObj === undefined) {
-                        // the entry doesn't exist, add it to our dictionary
-                        playedCommanderDictionary[commander.id] = {
-                            id: commander.id,
-                            name: currentCommanderName,
-                            colorIdentity: commander.color_identity,
-                            matches: [currentMatch.id],
-                            wins: player.rank === "1" ? 1 : 0,
-                        };
-                    } else {
-                        // since this commander exists, update the currentMatch count
-                        playedCommanderDictionary[potentialCommanderObj.id].matches.push(currentMatch.id);
-                        if (player.rank === "1") {
-                            playedCommanderDictionary[potentialCommanderObj.id].wins++;
-                        }
+            // loop through all commanders and update our commanders dictionary
+            for (const currentCommanderName of currentCommanderNames) {
+                const commander = commanderList[currentCommanderName];
+
+                // check to see if the commander name is valid
+                if (commander === undefined) {
+                    // log the invalid commander
+                    console.log(
+                        `Invalid commander found in currentMatch <${currentMatch.id}> : ${currentCommanderName}`,
+                    );
+                    continue;
+                }
+
+                // commander name is valid. let's check to see if we already added it to our dictionary
+                const potentialCommanderObj = playedCommanderDictionary[commander.id];
+                if (potentialCommanderObj === undefined) {
+                    // the entry doesn't exist, add it to our dictionary
+                    playedCommanderDictionary[commander.id] = {
+                        id: commander.id,
+                        name: currentCommanderName,
+                        colorIdentity: commander.color_identity,
+                        matches: [currentMatch.id],
+                        wins: player.rank === "1" ? 1 : 0,
+                    };
+                } else {
+                    // since this commander exists, update the currentMatch count
+                    playedCommanderDictionary[potentialCommanderObj.id].matches.push(currentMatch.id);
+                    if (player.rank === "1") {
+                        playedCommanderDictionary[potentialCommanderObj.id].wins++;
                     }
                 }
             }
@@ -58,58 +66,70 @@ export function getCommandersByPlayerNameHelper(matches: Match[], playerName: st
 }
 
 /**
- * Given a collection of matches and a commander NAME, create a dictionary of players who have played a specific commander
+ * Given a collection of matches, create a dictionary of players with optional filters
  * @param matches The collection of matches to bulid the dictionary from
- * @param commanderName The commander to filter players by
+ * @param commanderName An optional commander name to filter the users by (the user must have played this commander)
  * @returns A dictionary of player keyed by playerId
  */
-export function getPlayersByCommanderNameHelper(matches: Match[], commanderName: string): { [id: string]: Player } {
+export function matchesToPlayersHelper(
+    matches: Match[],
+    commanderNameFilter?: string
+): { [id: string]: Player } {
     const playerDictionary: { [id: string]: Player } = {};
     for (const currentMatch of matches) {
         // iterate through each player, and add those commanders to our commander dictionary
         for (const player of currentMatch.players) {
-            // loop through all commanders search for our match
+            // if any of the filters have a value, then we assume the player has failed the filter to start
+            let passedFilter = commanderNameFilter === undefined;
+
+            // loop through all commanders and apply our filter
             for (const currentCommanderName of player.commanders) {
-                if (currentCommanderName === commanderName) {
-                    // Commander is a match, let's check to see if player is already in our dictionary
-                    const potentialPlayerObj: Player | undefined = playerDictionary[player.name];
-                    if (potentialPlayerObj === undefined) {
+                if (currentCommanderName === commanderNameFilter) {
+                    passedFilter = true;
+                    break;
+                }
+            }
 
-                        // initialize the color profile dictionary
-                        const colorProfile: { [color: string]: number } = {};
-                        // compute the players color profile
-                        for (const commanderName of player.commanders) {
-                            const colors = commanderList[commanderName].color_identity;
-                            for (const color of colors) {
-                                // add or increment this in our colorProfile dictionary
-                                colorProfile[color] = (colorProfile[color] === undefined) ? 1 : colorProfile[color] + 1;
-                            }
+            if (passedFilter) {
+                // passed filters so we want to add this player.
+                // let's check to see if player is already in our dictionary.
+                const potentialPlayerObj: Player | undefined = playerDictionary[player.name];
+                if (potentialPlayerObj === undefined) {
+
+                    // initialize the color profile dictionary
+                    const colorProfile: { [color: string]: number } = {};
+                    // compute the players color profile
+                    for (const commanderName of player.commanders) {
+                        const colors = commanderList[commanderName].color_identity;
+                        for (const color of colors) {
+                            // add or increment this in our colorProfile dictionary
+                            colorProfile[color] = (colorProfile[color] === undefined) ? 1 : colorProfile[color] + 1;
                         }
+                    }
 
-                        // the entry doesn't exist, add it to our dictionary
-                        playerDictionary[player.name] = {
-                            name: player.name,
-                            matches: [currentMatch],
-                            wins: player.rank === "1" ? 1 : 0,
-                            colorProfile: colorProfile
-                        };
-                    } else {
-                        // since this player exists, update the currentMatch count
-                        playerDictionary[potentialPlayerObj.name].matches.push(currentMatch);
-                        if (player.rank === "1") {
-                            playerDictionary[potentialPlayerObj.name].wins++;
-                        }
+                    // the entry doesn't exist, add it to our dictionary
+                    playerDictionary[player.name] = {
+                        name: player.name,
+                        matches: [currentMatch],
+                        wins: player.rank === "1" ? 1 : 0,
+                        colorProfile: colorProfile
+                    };
+                } else {
+                    // since this player exists, update the currentMatch count
+                    playerDictionary[player.name].matches.push(currentMatch);
+                    if (player.rank === "1") {
+                        playerDictionary[player.name].wins++;
+                    }
 
-                        // compute the players color profile
-                        for (const commanderName of player.commanders) {
-                            const colors = commanderList[commanderName].color_identity;
-                            for (const color of colors) {
-                                // add or increment this in our colorProfile dictionary
-                                playerDictionary[player.name].colorProfile[color] =
-                                    playerDictionary[player.name].colorProfile[color] === undefined
-                                        ? 1
-                                        : playerDictionary[player.name].colorProfile[color] + 1;
-                            }
+                    // compute the players color profile
+                    for (const commanderName of player.commanders) {
+                        const colors = commanderList[commanderName].color_identity;
+                        for (const color of colors) {
+                            // add or increment this in our colorProfile dictionary
+                            playerDictionary[player.name].colorProfile[color] =
+                                playerDictionary[player.name].colorProfile[color] === undefined
+                                    ? 1
+                                    : playerDictionary[player.name].colorProfile[color] + 1;
                         }
                     }
                 }

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -39,7 +39,7 @@ export function getCommandersByPlayerNameHelper(matches: Match[], playerName: st
                         playedCommanderDictionary[commander.id] = {
                             id: commander.id,
                             name: currentCommanderName,
-                            color_identity: commander.color_identity,
+                            colorIdentity: commander.color_identity,
                             matches: [currentMatch.id],
                             wins: player.rank === "1" ? 1 : 0,
                         };
@@ -68,25 +68,48 @@ export function getPlayersByCommanderNameHelper(matches: Match[], commanderName:
     for (const currentMatch of matches) {
         // iterate through each player, and add those commanders to our commander dictionary
         for (const player of currentMatch.players) {
-            const playerCommanders: string[] = player.commanders;
-
             // loop through all commanders search for our match
-            for (const currentCommanderName of playerCommanders) {
+            for (const currentCommanderName of player.commanders) {
                 if (currentCommanderName === commanderName) {
                     // Commander is a match, let's check to see if player is already in our dictionary
                     const potentialPlayerObj: Player | undefined = playerDictionary[player.name];
                     if (potentialPlayerObj === undefined) {
+
+                        // initialize the color profile dictionary
+                        const colorProfile: { [color: string]: number } = {};
+                        // compute the players color profile
+                        for (const commanderName of player.commanders) {
+                            const colors = commanderList[commanderName].color_identity;
+                            for (const color of colors) {
+                                // add or increment this in our colorProfile dictionary
+                                colorProfile[color] = (colorProfile[color] === undefined) ? 1 : colorProfile[color] + 1;
+                            }
+                        }
+
                         // the entry doesn't exist, add it to our dictionary
                         playerDictionary[player.name] = {
                             name: player.name,
                             matches: [currentMatch],
                             wins: player.rank === "1" ? 1 : 0,
+                            colorProfile: colorProfile
                         };
                     } else {
                         // since this player exists, update the currentMatch count
                         playerDictionary[potentialPlayerObj.name].matches.push(currentMatch);
                         if (player.rank === "1") {
                             playerDictionary[potentialPlayerObj.name].wins++;
+                        }
+
+                        // compute the players color profile
+                        for (const commanderName of player.commanders) {
+                            const colors = commanderList[commanderName].color_identity;
+                            for (const color of colors) {
+                                // add or increment this in our colorProfile dictionary
+                                playerDictionary[player.name].colorProfile[color] =
+                                    playerDictionary[player.name].colorProfile[color] === undefined
+                                        ? 1
+                                        : playerDictionary[player.name].colorProfile[color] + 1;
+                            }
                         }
                     }
                 }

--- a/src/redux/statsReducer.ts
+++ b/src/redux/statsReducer.ts
@@ -70,7 +70,7 @@ function matchesToCommanders(matches: Match[]): { [id: string]: Commander } {
                     commanderDictionary[commander.id] = {
                         id: commander.id,
                         name: currentCommanderName,
-                        color_identity: commander.color_identity,
+                        colorIdentity: commander.color_identity,
                         matches: [currentMatch.id],
                         wins: player.rank === "1" ? 1 : 0,
                     };
@@ -93,7 +93,7 @@ function matchesToCommanders(matches: Match[]): { [id: string]: Commander } {
  * @returns a dictionary of players where the key is playerId and the value is a player
  */
 export function matchesToPlayers(matches: Match[]): { [name: string]: Player } {
-    const playerDictionary: { [name: string]: Player } = {};
+    const playerDictionary: { [id: string]: Player } = {};
     for (const currentMatch of matches) {
         // iterate through each player, and add those commanders to our commander dictionary
         for (const player of currentMatch.players) {
@@ -102,16 +102,41 @@ export function matchesToPlayers(matches: Match[]): { [name: string]: Player } {
 
             // if the entry doesn't exist, add to dictionary
             if (potentialPlayerObj === undefined) {
+
+                // initialize the color profile dictionary
+                const colorProfile: { [color: string]: number } = {};
+                // compute the players color profile
+                for (const commanderName of player.commanders) {
+                    const colors = commanderList[commanderName].color_identity;
+                    for (const color of colors) {
+                        // add or increment this in our colorProfile dictionary
+                        colorProfile[color] = (colorProfile[color] === undefined) ? 1 : colorProfile[color] + 1;
+                    }
+                }
+
                 playerDictionary[currentPlayerName] = {
                     name: currentPlayerName,
                     matches: [currentMatch],
                     wins: player.rank === "1" ? 1 : 0,
+                    colorProfile: colorProfile
                 };
             } else {
                 // since this player exists, update the currentMatch count
                 playerDictionary[currentPlayerName].matches.push(currentMatch);
                 if (player.rank === "1") {
                     playerDictionary[currentPlayerName].wins++;
+                }
+
+                // compute the players color profile
+                for (const commanderName of player.commanders) {
+                    const colors = commanderList[commanderName].color_identity;
+                    for (const color of colors) {
+                        // add or increment this in our colorProfile dictionary
+                        playerDictionary[currentPlayerName].colorProfile[color] =
+                            playerDictionary[currentPlayerName].colorProfile[color] === undefined
+                                ? 1
+                                : playerDictionary[currentPlayerName].colorProfile[color] += 1;
+                    }
                 }
             }
         }

--- a/src/redux/statsReducer.ts
+++ b/src/redux/statsReducer.ts
@@ -2,8 +2,8 @@ import { createReducer } from "@reduxjs/toolkit";
 import { Match } from "../types/domain/Match";
 import { StatsAction } from "./statsActions";
 import { Commander } from "../types/domain/Commander";
-import { commanderList } from "../services/commanderList";
 import { Player } from "../types/domain/Player";
+import { matchesToCommanderHelper, matchesToPlayersHelper } from "../logic/dictionaryUtils";
 
 /**
  * State containing all game history data
@@ -42,49 +42,7 @@ export const statsReducer = createReducer(initialState, (builder) => {
 
 // given a collection of matches, return all of the commanders in those matches
 function matchesToCommanders(matches: Match[]): { [id: string]: Commander } {
-    const commanderDictionary: { [id: string]: Commander } = {};
-    for (const currentMatch of matches) {
-        // iterate through each player, and add those commanders to our commander dictionary
-        for (const player of currentMatch.players) {
-            // there is a chance the commander is actually multiple commanders.
-            // the current separator for commanders is " && "
-            const currentCommanderNames: string[] = player.commanders;
-
-            // loop through all commanders and update our commanders dictionary
-            for (const currentCommanderName of currentCommanderNames) {
-                const commander = commanderList[currentCommanderName];
-
-                // check to see if the commander name is valid
-                if (commander === undefined) {
-                    // log the invalid commander
-                    console.log(
-                        `Invalid commander found in currentMatch <${currentMatch.id}> : ${currentCommanderName}`,
-                    );
-                    continue;
-                }
-
-                // commander name is valid. let's check to see if we already added it to our dictionary
-                const potentialCommanderObj = commanderDictionary[commander.id];
-                if (potentialCommanderObj === undefined) {
-                    // the entry doesn't exist, add it to our dictionary
-                    commanderDictionary[commander.id] = {
-                        id: commander.id,
-                        name: currentCommanderName,
-                        colorIdentity: commander.color_identity,
-                        matches: [currentMatch.id],
-                        wins: player.rank === "1" ? 1 : 0,
-                    };
-                } else {
-                    // since this commander exists, update the currentMatch count
-                    commanderDictionary[potentialCommanderObj.id].matches.push(currentMatch.id);
-                    if (player.rank === "1") {
-                        commanderDictionary[potentialCommanderObj.id].wins++;
-                    }
-                }
-            }
-        }
-    }
-    return commanderDictionary;
+    return matchesToCommanderHelper(matches);
 }
 
 /**
@@ -93,53 +51,5 @@ function matchesToCommanders(matches: Match[]): { [id: string]: Commander } {
  * @returns a dictionary of players where the key is playerId and the value is a player
  */
 export function matchesToPlayers(matches: Match[]): { [name: string]: Player } {
-    const playerDictionary: { [id: string]: Player } = {};
-    for (const currentMatch of matches) {
-        // iterate through each player, and add those commanders to our commander dictionary
-        for (const player of currentMatch.players) {
-            const currentPlayerName = player.name;
-            const potentialPlayerObj = playerDictionary[currentPlayerName];
-
-            // if the entry doesn't exist, add to dictionary
-            if (potentialPlayerObj === undefined) {
-
-                // initialize the color profile dictionary
-                const colorProfile: { [color: string]: number } = {};
-                // compute the players color profile
-                for (const commanderName of player.commanders) {
-                    const colors = commanderList[commanderName].color_identity;
-                    for (const color of colors) {
-                        // add or increment this in our colorProfile dictionary
-                        colorProfile[color] = (colorProfile[color] === undefined) ? 1 : colorProfile[color] + 1;
-                    }
-                }
-
-                playerDictionary[currentPlayerName] = {
-                    name: currentPlayerName,
-                    matches: [currentMatch],
-                    wins: player.rank === "1" ? 1 : 0,
-                    colorProfile: colorProfile
-                };
-            } else {
-                // since this player exists, update the currentMatch count
-                playerDictionary[currentPlayerName].matches.push(currentMatch);
-                if (player.rank === "1") {
-                    playerDictionary[currentPlayerName].wins++;
-                }
-
-                // compute the players color profile
-                for (const commanderName of player.commanders) {
-                    const colors = commanderList[commanderName].color_identity;
-                    for (const color of colors) {
-                        // add or increment this in our colorProfile dictionary
-                        playerDictionary[currentPlayerName].colorProfile[color] =
-                            playerDictionary[currentPlayerName].colorProfile[color] === undefined
-                                ? 1
-                                : playerDictionary[currentPlayerName].colorProfile[color] += 1;
-                    }
-                }
-            }
-        }
-    }
-    return playerDictionary;
+    return matchesToPlayersHelper(matches);
 }

--- a/src/redux/statsSelectors.ts
+++ b/src/redux/statsSelectors.ts
@@ -22,6 +22,20 @@ export const getMatch = (state: AppState, matchId: string) => {
 };
 
 /**
+ * Gets a specific commander based on commanderId.
+ */
+export const getCommander = (state: AppState, id: string) => {
+    return state.stats.commanders ? state.stats.commanders[id] : undefined;
+};
+
+/**
+ * Gets a specific player based on playerId.
+ */
+export const getPlayer = (state: AppState, id: string) => {
+    return state.stats.players ? state.stats.players[id] : undefined;
+}
+
+/**
  * Returns a collection matches in chronological order given a commander NAME. Note that this is not searching using commander id.
  */
 export const getMatchesByCommanderName = (
@@ -123,11 +137,4 @@ export const getPlayersByCommanderName = (
     );
 
     return players;
-};
-
-/**
- * Gets a specific commander based on commanderId.
- */
-export const getCommander = (state: AppState, id: string) => {
-    return state.stats.commanders ? state.stats.commanders[id] : undefined;
 };

--- a/src/redux/statsSelectors.ts
+++ b/src/redux/statsSelectors.ts
@@ -1,5 +1,4 @@
-import { getCommandersByPlayerNameHelper, getPlayersByCommanderNameHelper } from "../logic/dictionaryUtils";
-import { commanderList } from "../services/commanderList";
+import { matchesToCommanderHelper, matchesToPlayersHelper } from "../logic/dictionaryUtils";
 import { Commander } from "../types/domain/Commander";
 import { Match } from "../types/domain/Match";
 import { Player } from "../types/domain/Player";
@@ -109,7 +108,7 @@ export const getCommandersByPlayerName = (
     }
 
     const commanders = Object.values(
-        getCommandersByPlayerNameHelper(state.stats.matches, playerName),
+        matchesToCommanderHelper(state.stats.matches, playerName),
     );
 
     return commanders;
@@ -133,7 +132,7 @@ export const getPlayersByCommanderName = (
     }
 
     const players = Object.values(
-        getPlayersByCommanderNameHelper(state.stats.matches, commanderName),
+        matchesToPlayersHelper(state.stats.matches, commanderName),
     );
 
     return players;

--- a/src/types/domain/Commander.ts
+++ b/src/types/domain/Commander.ts
@@ -1,7 +1,7 @@
 export type Commander = {
     id: string;
     name: string;
-    color_identity: string[];
+    colorIdentity: string[];
     /**
      * A collection of match IDs of matches that the commander is played in
      */

--- a/src/types/domain/Player.ts
+++ b/src/types/domain/Player.ts
@@ -4,4 +4,9 @@ export type Player = {
     name: string;
     matches: Match[];
     wins: number;
+    /**
+     * A dictionary representing the colors of the commanders the player has played. 
+     * The key is the color as a string, and the value is the number of times that color has been played.
+     */
+    colorProfile: { [color: string]: number }
 }


### PR DESCRIPTION
Most notably: 
Add a colorProfile dictionary to Players so we can now know what types of commanders that player plays
Fix up the color piegraph to use the new dictionary from player correctly (moved the old calculation logic into statsReducer and dictionaryUtils)

BUG FIXES: 
1. fixed an issue where favorite commander was being populated before the data was ready
2. fixed an issue where navigating to a specific commander from a match details page would not work


next todo for davidpchi: need to refactor statsReducer + dictionaryUtils so they are using more shared code (they are very similar atm)