### PR TITLE
Added search bar in Command overview and details page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-redux": "^8.1.2",
         "react-router-dom": "^6.15.0",
         "react-scripts": "5.0.1",
+        "semantic-ui-react": "^2.1.4",
         "tinycolor2": "^1.4.2",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -3725,6 +3726,36 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fluentui/react-component-event-listener": {
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
+      "integrity": "sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@fluentui/react-component-ref": {
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.63.1.tgz",
+      "integrity": "sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.4",
+        "react-is": "^16.6.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@fluentui/react-component-ref/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -4708,6 +4739,19 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.3.tgz",
       "integrity": "sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw=="
+    },
+    "node_modules/@semantic-ui-react/event-stack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
+      "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
+      "dependencies": {
+        "exenv": "^1.2.2",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -7309,6 +7353,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -9351,6 +9403,11 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
     },
     "node_modules/exit": {
       "version": "0.1.2",
@@ -13496,6 +13553,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keyboard-key": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
+      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -13614,6 +13676,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -16276,6 +16343,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-redux": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.2.tgz",
@@ -17091,6 +17172,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/semantic-ui-react": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.4.tgz",
+      "integrity": "sha512-7CxjBoFUfH7fUvtn+SPkkIocthUD9kV3niF1mUMa9TbeyPAf2brtRCZBlT2OpHaXmkscFzGjEfhbJo9gKfotzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@fluentui/react-component-event-listener": "~0.63.0",
+        "@fluentui/react-component-ref": "~0.63.0",
+        "@popperjs/core": "^2.6.0",
+        "@semantic-ui-react/event-stack": "^3.1.3",
+        "clsx": "^1.1.1",
+        "keyboard-key": "^1.1.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6 || ^17.0.0 || ^18.0.0",
+        "react-popper": "^2.3.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -17258,6 +17363,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -18634,6 +18744,14 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -22115,6 +22233,30 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
       "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og=="
     },
+    "@fluentui/react-component-event-listener": {
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
+      "integrity": "sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==",
+      "requires": {
+        "@babel/runtime": "^7.10.4"
+      }
+    },
+    "@fluentui/react-component-ref": {
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.63.1.tgz",
+      "integrity": "sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==",
+      "requires": {
+        "@babel/runtime": "^7.10.4",
+        "react-is": "^16.6.3"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -22812,6 +22954,15 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.3.tgz",
       "integrity": "sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw=="
+    },
+    "@semantic-ui-react/event-stack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
+      "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
+      "requires": {
+        "exenv": "^1.2.2",
+        "prop-types": "^15.6.2"
+      }
     },
     "@sinclair/typebox": {
       "version": "0.24.51",
@@ -24752,6 +24903,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -26245,6 +26401,11 @@
         "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       }
+    },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
     },
     "exit": {
       "version": "0.1.2",
@@ -29241,6 +29402,11 @@
         "object.values": "^1.1.6"
       }
     },
+    "keyboard-key": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
+      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -29329,6 +29495,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -31080,6 +31251,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "requires": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      }
+    },
     "react-redux": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.2.tgz",
@@ -31612,6 +31792,26 @@
         "node-forge": "^1"
       }
     },
+    "semantic-ui-react": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.4.tgz",
+      "integrity": "sha512-7CxjBoFUfH7fUvtn+SPkkIocthUD9kV3niF1mUMa9TbeyPAf2brtRCZBlT2OpHaXmkscFzGjEfhbJo9gKfotzQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@fluentui/react-component-event-listener": "~0.63.0",
+        "@fluentui/react-component-ref": "~0.63.0",
+        "@popperjs/core": "^2.6.0",
+        "@semantic-ui-react/event-stack": "^3.1.3",
+        "clsx": "^1.1.1",
+        "keyboard-key": "^1.1.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6 || ^17.0.0 || ^18.0.0",
+        "react-popper": "^2.3.0",
+        "shallowequal": "^1.1.0"
+      }
+    },
     "semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -31760,6 +31960,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -32769,6 +32974,14 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-redux": "^8.1.2",
     "react-router-dom": "^6.15.0",
     "react-scripts": "5.0.1",
+    "semantic-ui-react": "^2.1.4",
     "tinycolor2": "^1.4.2",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -1,5 +1,6 @@
 import { TooltipItem } from "chart.js";
 import React, { useCallback, useState } from "react";
+import { Input } from 'semantic-ui-react'
 import { useSelector } from "react-redux";
 import { useLoaderData, useNavigate } from "react-router-dom";
 import { Flex, Heading, Image, Select, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from "@chakra-ui/react";
@@ -32,6 +33,11 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
         setDateFilter(date);
     }, [setDateFilter])
 
+    const [searchInput, setSearchInput] = useState('');
+    const onSearchChange = (searchValue: any) => {
+            setSearchInput(searchValue);
+    };
+
     const matches = useSelector((state: AppState) => getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter));
     const commanderPlayers: Player[] = useSelector((state: AppState) =>
         getPlayersByCommanderName(state, commander ? commander.name : "", dateFilter),
@@ -40,6 +46,18 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
 
     if (commander === undefined) {
         return <Loading text="" />;
+    }
+
+    let matchesArray: Match[] = matches;
+    if (searchInput.length > 0 && matches) {
+        matchesArray = matches.filter((match: Match) => {
+            for (let i = 0; i < match.players.length; i++) {
+                if (match.players[i].name.toLowerCase().includes(searchInput.toLowerCase())) {
+                    return true;
+                }
+            };
+            return false;
+        });
     }
 
     const title = commander.name.toUpperCase();
@@ -100,7 +118,16 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                     <Text>{`Color Identity: ${commander.colorIdentity}`}</Text>
                 </Flex>
             </Flex>
-            <DatePicker onChange={onDatePickerChange} />
+            <Flex>
+                <DatePicker onChange={onDatePickerChange} />
+                <div style={{ padding: 20 }}>
+                    <Input 
+                        icon='search' 
+                        placeholder='Search...'
+                        onChange={(e) => onSearchChange(e.target.value)}
+                    />
+                </div>
+            </Flex>
             <Tabs isFitted={true} width={"100%"} paddingRight={"10%"} paddingLeft={"10%"}>
                 <TabList>
                     <Tab>
@@ -116,9 +143,9 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                 <TabPanels>
                     <TabPanel>
                         {
-                            matches.length > 0 ? <SortableTable
+                            matchesArray.length > 0 ? <SortableTable
                                 columns={matchHistoryColumns}
-                                data={matches}
+                                data={matchesArray}
                                 getRowProps={(row: any) => {
                                     return {
                                         onClick: () => {

--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -34,9 +34,9 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
     }, [setDateFilter])
 
     const [searchInput, setSearchInput] = useState('');
-    const onSearchChange = (searchValue: any) => {
-            setSearchInput(searchValue);
-    };
+    const onSearchChange = useCallback((event: any) => {
+        setSearchInput(event.target.value);
+    }, [setSearchInput]);
 
     const matches = useSelector((state: AppState) => getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter));
     const commanderPlayers: Player[] = useSelector((state: AppState) =>
@@ -51,10 +51,15 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
     let matchesArray: Match[] = matches;
     if (searchInput.length > 0 && matches) {
         matchesArray = matches.filter((match: Match) => {
-            for (let i = 0; i < match.players.length; i++) {
-                if (match.players[i].name.toLowerCase().includes(searchInput.toLowerCase())) {
+            for (let player of match.players) {
+                if (player.name.toLowerCase().includes(searchInput.toLowerCase())) {
                     return true;
                 }
+                for (let comm of player.commanders) {
+                    if (comm.toLowerCase().includes(searchInput.toLowerCase())) {
+                        return true;
+                    }
+                }  
             };
             return false;
         });
@@ -124,7 +129,7 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                     <Input 
                         icon='search' 
                         placeholder='Search...'
-                        onChange={(e) => onSearchChange(e.target.value)}
+                        onChange={onSearchChange}
                     />
                 </div>
             </Flex>

--- a/src/components/commanderOverview/CommanderOverview.tsx
+++ b/src/components/commanderOverview/CommanderOverview.tsx
@@ -1,5 +1,6 @@
-import { Checkbox, Flex, Heading, Select, Tooltip, Text } from "@chakra-ui/react";
+import { Checkbox, Flex, Heading, Select, Tooltip, Text, filter } from "@chakra-ui/react";
 import React, { useCallback, useState } from "react";
+import { Input } from 'semantic-ui-react'
 import { SortableTable } from "../dataVisualizations/SortableTable";
 import { commanderOverviewColumns } from "./commanderOverviewColumnHelper";
 import { getCommanders, getCommandersByDate } from "../../redux/statsSelectors";
@@ -22,9 +23,13 @@ export const CommanderOverview = React.memo(function MatchHistory() {
     const allCommanders = useSelector(getCommanders);
     const commanders: Commander[] = useSelector((state: AppState) => getCommandersByDate(state, dateFilter));
     const [isFiltered, setIsFiltered] = useState<boolean>(true);
-
     const onFilterChange = () => {
         setIsFiltered(!isFiltered);
+    };
+    
+    const [searchInput, setSearchInput] = useState('');
+    const onSearchChange = (searchValue: any) => {
+            setSearchInput(searchValue);
     };
 
     if (commanders === undefined) {
@@ -37,7 +42,9 @@ export const CommanderOverview = React.memo(function MatchHistory() {
             (value: Commander) => allCommanders[value.id].matches.length >= COMMANDER_MINIMUM_GAMES_REQUIRED,
         );
     }
-
+    if (searchInput.length > 0 && allCommanders) {
+        commandersArray = commandersArray.filter((value: Commander) => allCommanders[value.id].name.toLowerCase().includes(searchInput.toLowerCase()));
+    }
 
     return (
         <Flex direction="column" justify="center" align="center">
@@ -55,6 +62,13 @@ export const CommanderOverview = React.memo(function MatchHistory() {
                         </Checkbox>
                     </div>
                 </Tooltip>
+                <div style={{ padding: 20 }}>
+                    <Input 
+                        icon='search' 
+                        placeholder='Search...'
+                        onChange={(e) => onSearchChange(e.target.value)}
+                    />
+                </div>
             </Flex>
             {
                 commandersArray.length ? <SortableTable

--- a/src/components/commanderOverview/CommanderOverview.tsx
+++ b/src/components/commanderOverview/CommanderOverview.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, Flex, Heading, Select, Tooltip, Text, filter } from "@chakra-ui/react";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Input } from 'semantic-ui-react'
 import { SortableTable } from "../dataVisualizations/SortableTable";
 import { commanderOverviewColumns } from "./commanderOverviewColumnHelper";
@@ -27,11 +27,11 @@ export const CommanderOverview = React.memo(function MatchHistory() {
         setIsFiltered(!isFiltered);
     };
     
-    const [searchInput, setSearchInput] = useState('');
-    const onSearchChange = (searchValue: any) => {
-            setSearchInput(searchValue);
-    };
-
+    const [searchInput, setSearchInput] = useState<string>('');
+    const onSearchChange = useCallback((event: any) => {
+            setSearchInput(event.target.value);
+    }, [setSearchInput]);
+    
     if (commanders === undefined) {
         return <Loading text="Loading..." />;
     }
@@ -66,7 +66,7 @@ export const CommanderOverview = React.memo(function MatchHistory() {
                     <Input 
                         icon='search' 
                         placeholder='Search...'
-                        onChange={(e) => onSearchChange(e.target.value)}
+                        onChange={onSearchChange}
                     />
                 </div>
             </Flex>


### PR DESCRIPTION
### Summary
Added search bar in Command overview and details page.  

### Screenshots
- Commander overview page: <img width="400" alt="Commander overview page" src="https://github.com/davidpchi/toski/assets/38110685/53626afb-88dc-4243-a1e3-424fe4a90961">
- Commander details page: <img width="400" alt="Commander details page" src="https://github.com/davidpchi/toski/assets/38110685/7d61ce2d-93e7-4fe1-8475-f25d4d9e39c2">

### Details
- It is a search-as-you-type instead of a search button. Let me know if you prefer the button.  
- In the details page, I only applied the search in the `Match history` and not on the `Historical winrate`. Let me know if you filter out the historical data as well. 
- There is no styling. Any suggestion on styling? Do we have a UX design mock? 😆 