### PR TITLE
First set of changes to support new moonmist navigation + tables

### DIFF
--- a/src/components/SidebarWithHeader.tsx
+++ b/src/components/SidebarWithHeader.tsx
@@ -15,11 +15,12 @@ import {
     useDisclosure,
     VStack,
 } from "@chakra-ui/react";
-import { ReactNode, useCallback } from "react";
+import { ReactNode, useCallback, useMemo } from "react";
 import { IconType } from "react-icons";
 import { FiBarChart, FiCalendar, FiHome, FiMenu, FiRss, FiShield, FiTrendingUp, FiUsers } from "react-icons/fi";
 import { useLocation, useNavigate } from "react-router-dom";
 import { FF_IS_NEWS_ENABLED } from "../services/featureFlagService";
+import { routes } from "../navigation/routes";
 
 interface LinkItemProps {
     name: string;
@@ -53,11 +54,10 @@ export default function SidebarWithHeader({ children }: { children: ReactNode })
                     <SidebarContent onClose={onClose} />
                 </DrawerContent>
             </Drawer>
-            {/* mobilenav */}
             <Box>
-                <MobileNav onOpen={onOpen} />
+                <Header onOpen={onOpen} />
             </Box>
-            <Box ml={{ base: 0, md: 60 }} p="4">
+            <Box ml={{ base: 0, md: 60 }} p="8">
                 {children}
                 <Flex
                     height={"64px"}
@@ -104,18 +104,26 @@ const SidebarContent = ({ onClose, ...rest }: SidebarProps) => {
             h="full"
             {...rest}
         >
-            <Flex h="20" align="center" mx="8" justify="space-between">
-                <Flex direction="column" justify="center" align="center">
-                    <Text fontSize="20" fontWeight="bold" textTransform="uppercase" color="gray.600" noOfLines={1}>
-                        Project Toski
-                    </Text>
-                    <Text fontSize="10px" alignSelf={"flex-end"}>
-                        Alpha
-                    </Text>
-                </Flex>
+            <Flex
+                h="20"
+                align="center"
+                paddingRight={"8px"}
+                paddingLeft={"8px"}
+                justifyContent="space-between"
+                backgroundColor={"white"}
+            >
+                <Text fontSize="20" fontWeight="bold" textTransform="uppercase" color="gray.600" noOfLines={1}>
+                    Project Toski
+                </Text>
                 <CloseButton display={{ base: "flex", md: "none" }} onClick={onClose} />
             </Flex>
-            <VStack spacing="24px" align="stretch" justify="flex-start">
+            <VStack
+                spacing="24px"
+                align="stretch"
+                height={"100%"}
+                justify="flex-start"
+                boxShadow={"0px 12px 18px 2px rgba(0,0,0,0.3)"}
+            >
                 {linkItems.map((link) => (
                     <NavItem
                         key={link.name}
@@ -169,19 +177,58 @@ const NavItem = ({ icon, label, route, onClose }: NavItemProps) => {
     );
 };
 
-interface MobileProps extends FlexProps {
+interface HeaderProps extends FlexProps {
     onOpen: () => void;
 }
-const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
+
+const useHeaderTitle = () => {
+    const location = useLocation();
+
+    return useMemo(() => {
+        let title = "";
+
+        const path = location.pathname;
+
+        // check each of the potential "areas" of the app that may need more specific titles
+        if (path.includes("commanderOverview")) {
+            title = "Commander Overview";
+        } else if (path.includes("matchHistory")) {
+            title = "Match History";
+        } else if (path.includes("playerOverview")) {
+            title = "Player Overview";
+        } else if (path.includes("articles")) {
+            title = "Articles";
+        } else {
+            const route = routes[path];
+
+            // if the route doesn't exist, just return the default;
+            if (route !== undefined) {
+                title = route.name;
+            }
+        }
+
+        return title;
+    }, [location]);
+};
+
+// the md layout is used for normal
+// the base layout is used for mobile view
+const Header = ({ onOpen, ...rest }: HeaderProps) => {
+    const headerTitle = useHeaderTitle();
+    const location = useLocation();
+    const isHome = location.pathname === "/";
+
     return (
         <Flex
             ml={{ base: 0, md: 60 }}
             px={{ base: 4, md: 4 }}
-            height="20"
+            display={{ base: "fixed", md: isHome ? "none" : "fixed" }}
+            height={20}
             align="center"
             borderBottomWidth="1px"
             borderBottomColor={useColorModeValue("gray.200", "gray.700")}
-            justify={{ base: "space-between", md: "flex-end" }}
+            justify={{ base: "space-between", md: "flex-start" }}
+            boxShadow={"0px 12px 18px -12px rgba(0,0,0,0.3)"}
             {...rest}
         >
             <IconButton
@@ -192,22 +239,11 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
                 icon={<FiMenu />}
             />
 
-            <Box display={{ base: "flex", md: "none" }}>
-                <Flex direction="column" justify="center" align="center">
-                    <Text
-                        fontSize="2xl"
-                        fontFamily="monospace"
-                        fontWeight="bold"
-                        textTransform="uppercase"
-                        color="gray.600"
-                    >
-                        PROJECT TOSKI
-                    </Text>
-                    <Text fontSize="10px" alignSelf={"flex-end"}>
-                        Alpha
-                    </Text>
-                </Flex>
-            </Box>
+            <Flex alignItems={"flex-start"}>
+                <Text fontSize="20" fontWeight="bold" textTransform="uppercase" color="gray.600">
+                    {headerTitle}
+                </Text>
+            </Flex>
         </Flex>
     );
 };

--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -2,7 +2,7 @@ import { TooltipItem } from "chart.js";
 import React, { useCallback, useState } from "react";
 import { useSelector } from "react-redux";
 import { useLoaderData, useNavigate } from "react-router-dom";
-import { Flex, Heading, Image, Input, Select, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from "@chakra-ui/react";
+import { Flex, Image, Input, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from "@chakra-ui/react";
 
 import { AppState } from "../../redux/rootReducer";
 import { getCommander, getMatchesByCommanderName, getPlayersByCommanderName } from "../../redux/statsSelectors";
@@ -73,8 +73,6 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
         });
     }
 
-    const title = commander.name.toUpperCase();
-
     let numberOfWins = 0;
 
     const winratePerMatch = matches.map((match: Match, index: number) => {
@@ -107,7 +105,6 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
 
     return (
         <Flex direction="column" justify="center" align="center">
-            <Heading>{title}</Heading>
             <Flex
                 direction="row"
                 maxWidth={"1024px"}
@@ -210,8 +207,8 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                         )}
                     </TabPanel>
                     <TabPanel>
-                    {matchesArray.length > 0 ? (
-                            <MatchPlacementBarChart matches={matchesArray} commanderName={commander.name}/>
+                        {matchesArray.length > 0 ? (
+                            <MatchPlacementBarChart matches={matchesArray} commanderName={commander.name} />
                         ) : (
                             <div style={{ textAlign: "center" }}>No data</div>
                         )}

--- a/src/components/commanderOverview/CommanderOverview.tsx
+++ b/src/components/commanderOverview/CommanderOverview.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Flex, Heading, Tooltip, Input } from "@chakra-ui/react";
+import { Checkbox, Flex, Tooltip, Input } from "@chakra-ui/react";
 import React, { useCallback, useState } from "react";
 import { SortableTable } from "../dataVisualizations/SortableTable";
 import { commanderOverviewColumns } from "./commanderOverviewColumnHelper";
@@ -55,7 +55,6 @@ export const CommanderOverview = React.memo(function MatchHistory() {
 
     return (
         <Flex direction="column" justify="center" align="center">
-            <Heading>Commander Overview</Heading>
             <Flex alignSelf={"center"} marginBottom={"16px"} alignItems={"center"}>
                 <DatePicker onChange={onDatePickerChange} />
                 <Tooltip

--- a/src/components/commanderTrends/CommanderTrends.tsx
+++ b/src/components/commanderTrends/CommanderTrends.tsx
@@ -42,7 +42,6 @@ export const CommanderTrends = React.memo(function CommanderTrends() {
 
     return (
         <Flex direction="column" justify="center" align="center">
-            <Heading>Commander Trends</Heading>
             <Heading size="md">Commander Colors Played</Heading>
             <Flex maxWidth={175} maxHeight={175}>
                 <div style={{ flex: 1, display: "flex", width: "100%", height: "100%" }}>

--- a/src/components/commanderTrends/CommandersPlayedChart.tsx
+++ b/src/components/commanderTrends/CommandersPlayedChart.tsx
@@ -1,6 +1,6 @@
 import { TooltipItem } from "chart.js";
 import React from "react";
-import { Heading, Text } from "@chakra-ui/react";
+import { Heading } from "@chakra-ui/react";
 
 import { Match } from "../../types/domain/Match";
 import { LineGraph } from "../dataVisualizations/LineGraph";

--- a/src/components/dataVisualizations/SortableTable.tsx
+++ b/src/components/dataVisualizations/SortableTable.tsx
@@ -46,7 +46,13 @@ export function SortableTable({
     });
 
     return (
-        <TableContainer border="1px solid" borderColor="#E2E8F0" borderRadius="md" backgroundColor="white">
+        <TableContainer
+            border="0px"
+            borderColor="#E2E8F0"
+            borderRadius="md"
+            backgroundColor="white"
+            boxShadow={"0px 12px 18px -6px rgba(0,0,0,0.3)"}
+        >
             <Table>
                 <Thead>
                     {table.getHeaderGroups().map((headerGroup) => (

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -12,7 +12,6 @@ export default function Home() {
         <Flex
             style={{
                 minHeight: "90vh",
-                backgroundColor: "#282c34",
                 margin: -16,
                 position: "relative",
             }}

--- a/src/components/home/HomeNewsSection.tsx
+++ b/src/components/home/HomeNewsSection.tsx
@@ -13,7 +13,7 @@ export const HomeNewsSection = React.memo(function HomeNewsSection() {
     };
 
     return (
-        <Flex backgroundColor="white" flexDirection="column" alignItems="center" paddingTop="4" paddingBottom="4">
+        <Flex flexDirection="column" alignItems="center" paddingTop="4" paddingBottom="4">
             <Flex maxWidth="1024px" flexDirection="column" wrap="wrap">
                 <Button
                     variant="ghost"

--- a/src/components/matchHistory/MatchDetails.tsx
+++ b/src/components/matchHistory/MatchDetails.tsx
@@ -45,10 +45,10 @@ export const MatchDetails = React.memo(function MatchDetails() {
 
     return (
         <Flex direction="column" justify="center" align="center">
-            <Heading>{title}</Heading>
             <Flex direction={"row"} flex={1} marginBottom={8} flexWrap={"wrap"}>
                 {playerCards}
             </Flex>
+            <Heading size="md">{title}</Heading>
             {match.winner ? <Text>{`Winner: ${match.winner}`}</Text> : null}
             {match.numberOfTurns ? <Text>{`Number of turns: ${match.numberOfTurns}`}</Text> : null}
         </Flex>

--- a/src/components/matchHistory/MatchHistory.tsx
+++ b/src/components/matchHistory/MatchHistory.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 import React from "react";
 import { SortableTable } from "../dataVisualizations/SortableTable";
 import { matchHistoryColumns } from "./matchHistoryColumnHelper";
@@ -21,7 +21,6 @@ export const MatchHistory = React.memo(function MatchHistory() {
 
     return (
         <Flex direction="column" justify="center" align="center">
-            <Heading>Match History</Heading>
             <SortableTable
                 columns={matchHistoryColumns}
                 data={matches}

--- a/src/components/matchTrends/MatchTrends.tsx
+++ b/src/components/matchTrends/MatchTrends.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Flex, Heading } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 
 import { MatchLengthLineChart } from "./MatchLengthLineChart";
 import { getMatches, getPlayersByDate } from "../../redux/statsSelectors";
@@ -42,7 +42,6 @@ export const MatchTrends = React.memo(function MatchHistory() {
 
     return (
         <Flex direction="column" justify="center" align="center">
-            <Heading>Match Trends</Heading>
             <MatchLengthBarChart matches={sortedMatches} />
             <MatchLengthLineChart matches={sortedMatches} />
             <MatchFrequencyLineChart matches={sortedMatches} />

--- a/src/components/playerOverview/PlayerOverview.tsx
+++ b/src/components/playerOverview/PlayerOverview.tsx
@@ -46,7 +46,6 @@ export const PlayerOverview = React.memo(function MatchHistory() {
 
     return (
         <Flex direction="column" justify="center" align="center">
-            <Heading>Player Overview</Heading>
             <Flex alignSelf={"center"} marginBottom={"16px"} alignItems={"center"}>
                 <DatePicker onChange={onDatePickerChange} />
                 <Tooltip

--- a/src/navigation/routes.tsx
+++ b/src/navigation/routes.tsx
@@ -15,64 +15,85 @@ import { loader as newsLoader, NewsDetail } from "../components/news/NewsDetail"
 import { MatchSubmission } from "../components/matchHistory/MatchSubmission";
 import { CommanderTrends } from "../components/commanderTrends/CommanderTrends";
 
+type route = {
+    name: string;
+    path: string;
+    loader?: any;
+    element: JSX.Element;
+};
+
+export const routes: { [path: string]: route } = {
+    "/": {
+        name: "Project Toski",
+        path: "/",
+        element: <Home />,
+    },
+    "/playerOverview": {
+        name: "Player Overview",
+        path: "/playerOverview",
+        element: <PlayerOverview />,
+    },
+    "/playerOverview/:playerId": {
+        name: "Player Details",
+        path: "/playerOverview/:playerId",
+        loader: playerLoader,
+        element: <PlayerDetails />,
+    },
+    "/matchHistory": {
+        name: "Match History",
+        path: "/matchHistory",
+        element: <MatchHistory />,
+    },
+    "/matchHistory/:matchId": {
+        name: "Match Details",
+        path: "/matchHistory/:matchId",
+        loader: matchLoader,
+        element: <MatchDetails />,
+    },
+    "/matchTrends": {
+        name: "Match Trends",
+        path: "/matchTrends",
+        element: <MatchTrends />,
+    },
+    "/commanderOverview": {
+        name: "Commander Overview",
+        path: "/commanderOverview",
+        element: <CommanderOverview />,
+    },
+    "/commanderTrends": {
+        name: "Commander Trends",
+        path: "/commanderTrends",
+        element: <CommanderTrends />,
+    },
+    "/commanderOverview/:commanderId": {
+        name: "Commander Details",
+        path: "/commanderOverview/:commanderId",
+        loader: commanderLoader,
+        element: <CommanderDetails />,
+    },
+    "/articles": {
+        name: "Articles",
+        path: "/articles",
+        element: <NewsOverview />,
+    },
+    "/articles/:newsId": {
+        name: "Articles",
+        path: "/articles/:newsId",
+        loader: newsLoader,
+        element: <NewsDetail />,
+    },
+    "/matchHistory/submit": {
+        name: "Match History Submission",
+        path: "/matchHistory/submit",
+        element: <MatchSubmission />,
+    },
+};
+
 export const router = createHashRouter([
     {
         path: "/",
         element: <Root />,
         errorElement: <Error error={"Whoops! Made a wrong turn!"} />,
-        children: [
-            {
-                path: "/",
-                element: <Home />,
-            },
-            {
-                path: "/playerOverview",
-                element: <PlayerOverview />,
-            },
-            {
-                path: "/playerOverview/:playerId",
-                loader: playerLoader,
-                element: <PlayerDetails />,
-            },
-            {
-                path: "/matchHistory",
-                element: <MatchHistory />,
-            },
-            {
-                path: "/matchHistory/:matchId",
-                loader: matchLoader,
-                element: <MatchDetails />,
-            },
-            {
-                path: "/matchTrends",
-                element: <MatchTrends />,
-            },
-            {
-                path: "/commanderOverview",
-                element: <CommanderOverview />,
-            },
-            {
-                path: "/commanderTrends",
-                element: <CommanderTrends />,
-            },
-            {
-                path: "/commanderOverview/:commanderId",
-                loader: commanderLoader,
-                element: <CommanderDetails />,
-            },
-            {
-                path: "/articles",
-                element: <NewsOverview />,
-            },
-            {
-                path: "/articles/:newsId",
-                loader: newsLoader,
-                element: <NewsDetail />,
-            },
-            {
-                path: "/matchHistory/submit",
-                element: <MatchSubmission />,
-            },
-        ],
+        children: Object.values(routes),
     },
 ]);


### PR DESCRIPTION
this set of changes removes heading titles from all pages in the site and migrates to a new header that renders it's text based on the route that you are on. 

As a result, had to update the routes a little bit to potentially support dynamic titles. 

Also, revamped the headers + sidebar to properly handle new sizes AND add box shadow.

Tables now also have box shadow and updated styles too. 