### PR TITLE
Filter for player counts in games

### DIFF
--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -2,7 +2,7 @@ export const PLAYER_MINIMUM_GAMES_REQUIRED = 10;
 export const PLAYER_MINIMUM_WINS_REQUIRED = 5; // Used for average win turn
 export const COMMANDER_MINIMUM_GAMES_REQUIRED = 5;
 export const NEW_PLAYER_HIGHLIGHT_DAYS = 7; // Used for highlighting newly qualified players in the playerOverview list
-export const NUMBER_OF_PLAYERS_FOR_VALID_GAME = 4; // Used for filtering out non four player games
+export const NUMBER_OF_PLAYERS_FOR_VALID_MATCH = 4; // Used for filtering out matches without 4 players
 
 export const MTG_COLORS: { name: string; id: string; rgb: string }[] = [
     { name: "Black", id: "B", rgb: "rgb(166, 159, 157)" },

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -2,6 +2,7 @@ export const PLAYER_MINIMUM_GAMES_REQUIRED = 10;
 export const PLAYER_MINIMUM_WINS_REQUIRED = 5; // Used for average win turn
 export const COMMANDER_MINIMUM_GAMES_REQUIRED = 5;
 export const NEW_PLAYER_HIGHLIGHT_DAYS = 7; // Used for highlighting newly qualified players in the playerOverview list
+export const NUMBER_OF_PLAYERS_FOR_VALID_GAME = 4; // Used for filtering out non four player games
 
 export const MTG_COLORS: { name: string; id: string; rgb: string }[] = [
     { name: "Black", id: "B", rgb: "rgb(166, 159, 157)" },

--- a/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
@@ -84,7 +84,7 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
                     borderLeftWidth={1}
                     borderRightWidth={1}
                     borderBottomWidth={1}
-                >{`Winrate: ${getWinRatePercentage(player.wins, player.validMatches)}%`}</Text>
+                >{`Winrate: ${getWinRatePercentage(player.wins, player.validMatchesCount)}%`}</Text>
                 <Text
                     paddingLeft={"16px"}
                     paddingRight={"16px"}

--- a/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
@@ -84,7 +84,7 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
                     borderLeftWidth={1}
                     borderRightWidth={1}
                     borderBottomWidth={1}
-                >{`Winrate: ${getWinRatePercentage(player.wins, player.matches.length)}%`}</Text>
+                >{`Winrate: ${getWinRatePercentage(player.wins, player.validMatches)}%`}</Text>
                 <Text
                     paddingLeft={"16px"}
                     paddingRight={"16px"}

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -4,19 +4,18 @@ import { Match } from "../types/domain/Match";
 import { Player } from "../types/domain/Player";
 
 /**
- * Given a collection of Matches, filters them to matches after a certain date.
- * Optionally, provide an end date as well.
- * @param matches
- * @param startDate
- * @param endDate
- * @returns
+ * Given a collection of Matches, filter out games that don't have the desired number of players
+ * "Seats" refers to the desired number of seats in matches to keep (usually 4)
+ * @param matches 
+ * @param seats 
+ * @returns 
  */
 
 export function filterMatchesBySeatCount(matches: Match[], seats: number): Match[] {
     const result = [];
 
     for (const match of matches) {
-        if (match.players.length != seats) {
+        if (match.players.length !== seats) {
             continue;
         }
 
@@ -25,6 +24,15 @@ export function filterMatchesBySeatCount(matches: Match[], seats: number): Match
 
     return result;
 }
+
+/**
+ * Given a collection of Matches, filters them to matches after a certain date.
+ * Optionally, provide an end date as well.
+ * @param matches
+ * @param startDate
+ * @param endDate
+ * @returns
+ */
 
 export function filterMatchesByDate(matches: Match[], startDate?: Date, endDate?: Date): Match[] {
     const result = [];

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -1,4 +1,3 @@
-import { match } from "assert";
 import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../components/constants";
 import { commanderList } from "../services/commanderList";
 import { Commander } from "../types/domain/Commander";
@@ -6,9 +5,9 @@ import { Match } from "../types/domain/Match";
 import { Player } from "../types/domain/Player";
 
 /**
- * Given a collection of Matches, filter out games that don't have the desired number of players
+ * Given a collection of Matches, filter out games that don't have the desired number of players.
  * @param matches 
- * @param playerCount "Seats" refers to the desired number of seats in matches to keep (usually 4)
+ * @param playerCount "playerCount" refers to the desired number of players in matches to keep (usually 4).
  * @returns 
  */
 export function filterMatchesByPlayerCount(matches: Match[], playerCount: number): Match[] {

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -1,5 +1,5 @@
 import { match } from "assert";
-import { NUMBER_OF_PLAYERS_FOR_VALID_GAME } from "../components/constants";
+import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../components/constants";
 import { commanderList } from "../services/commanderList";
 import { Commander } from "../types/domain/Commander";
 import { Match } from "../types/domain/Match";
@@ -62,16 +62,12 @@ export function matchesToCommanderHelper(
     playerNameFilter?: string,
     startDate?: Date,
 ): { [id: string]: Commander } {
-
     const filteredMatches = filterMatchesByDate(matches, startDate);
-
-    const filteredMatchesByPC = filterMatchesByPlayerCount(filteredMatches, 4);
 
     const playedCommanderDictionary: { [id: string]: Commander } = {};
     for (const currentMatch of filteredMatches) {
         // iterate through each player, and add those commanders to our commander dictionary
         for (const player of currentMatch.players) {
-
             // apply our filters
             if (playerNameFilter !== undefined && player.name !== playerNameFilter) {
                 // we have an active playerName filter-- if the player name is not a match, then we skip it
@@ -104,15 +100,15 @@ export function matchesToCommanderHelper(
                         name: currentCommanderName,
                         colorIdentity: commander.color_identity,
                         matches: [currentMatch.id],
-                        validMatches: currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_GAME ? 1 : 0,
-                        wins: player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_GAME ? 1 : 0,
+                        validMatchesCount: currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH ? 1 : 0,
+                        wins: player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH ? 1 : 0,
                     };
                 } else {
                     // since this commander exists, update the currentMatch count
                     playedCommanderDictionary[potentialCommanderObj.id].matches.push(currentMatch.id);
-                    if (player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_GAME) {
+                    if (player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
                         playedCommanderDictionary[potentialCommanderObj.id].wins++;
-                        playedCommanderDictionary[potentialCommanderObj.id].validMatches++;
+                        playedCommanderDictionary[potentialCommanderObj.id].validMatchesCount++;
                     }
                 }
             }
@@ -170,15 +166,15 @@ export function matchesToPlayersHelper(
                     playerDictionary[player.name] = {
                         name: player.name,
                         matches: [currentMatch],
-                        validMatches: currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_GAME ? 1 : 0,
-                        wins: player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_GAME ? 1 : 0,
+                        validMatchesCount: currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH ? 1 : 0,
+                        wins: player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH ? 1 : 0,
                         colorProfile: colorProfile,
                     };
                 } else {
                     // since this player exists, update the currentMatch count
                     playerDictionary[player.name].matches.push(currentMatch);
-                    if (player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_GAME) {
-                        playerDictionary[player.name].validMatches++;
+                    if (player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
+                        playerDictionary[player.name].validMatchesCount++;
                         playerDictionary[player.name].wins++;
                     }
 

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -11,6 +11,21 @@ import { Player } from "../types/domain/Player";
  * @param endDate
  * @returns
  */
+
+export function filterMatchesBySeatCount(matches: Match[], seats: number): Match[] {
+    const result = [];
+
+    for (const match of matches) {
+        if (match.players.length != seats) {
+            continue;
+        }
+
+        result.push(match);
+    }
+
+    return result;
+}
+
 export function filterMatchesByDate(matches: Match[], startDate?: Date, endDate?: Date): Match[] {
     const result = [];
 
@@ -40,12 +55,13 @@ export function matchesToCommanderHelper(
     playerNameFilter?: string,
     startDate?: Date,
 ): { [id: string]: Commander } {
-    const filteredMatches = filterMatchesByDate(matches, startDate);
+    const filteredMatches = filterMatchesBySeatCount(filterMatchesByDate(matches, startDate), 4);
 
     const playedCommanderDictionary: { [id: string]: Commander } = {};
     for (const currentMatch of filteredMatches) {
         // iterate through each player, and add those commanders to our commander dictionary
         for (const player of currentMatch.players) {
+
             // apply our filters
             if (playerNameFilter !== undefined && player.name !== playerNameFilter) {
                 // we have an active playerName filter-- if the player name is not a match, then we skip it
@@ -104,7 +120,7 @@ export function matchesToPlayersHelper(
     commanderNameFilter?: string,
     startDate?: Date,
 ): { [id: string]: Player } {
-    const filteredMatches = filterMatchesByDate(matches, startDate);
+    const filteredMatches = filterMatchesBySeatCount(filterMatchesByDate(matches, startDate), 4);
 
     const playerDictionary: { [id: string]: Player } = {};
     for (const currentMatch of filteredMatches) {

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -7,7 +7,7 @@ import { Player } from "../types/domain/Player";
 /**
  * Given a collection of Matches, filter out games that don't have the desired number of players.
  * @param matches 
- * @param playerCount "playerCount" refers to the desired number of players in matches to keep (usually 4).
+ * @param playerCount The number of players in the match that matches will be filtered by.
  * @returns 
  */
 export function filterMatchesByPlayerCount(matches: Match[], playerCount: number): Match[] {

--- a/src/logic/utils.test.ts
+++ b/src/logic/utils.test.ts
@@ -37,6 +37,7 @@ describe("getAverageWinTurn", () => {
         player = {
             name: "John",
             matches: matches,
+            validMatches: 10,
             wins: 7,
             colorProfile: {},
         };

--- a/src/logic/utils.test.ts
+++ b/src/logic/utils.test.ts
@@ -37,7 +37,7 @@ describe("getAverageWinTurn", () => {
         player = {
             name: "John",
             matches: matches,
-            validMatches: 10,
+            validMatchesCount: 10,
             wins: 7,
             colorProfile: {},
         };

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -19,8 +19,8 @@ export function getAverageWinTurn(player: Player) {
 
     // Get win turn for every match win
     for (const match of player.matches) {
-        if (player.name === match.winner) {
-            // Exclude wins without turns data
+        if (player.name === match.winner && match.players.length == 4) {
+            // Exclude wins without turns data or fewer than 4 players
             if (Number(match.numberOfTurns) > 0) {
                 winTurns.push(Number(match.numberOfTurns));
             }

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -12,7 +12,7 @@ export function getWinRatePercentage(winCount: number, totalCount: number) {
 export function getAverageWinTurn(player: Player) {
     // Early exit conditions
     // Don't show if player has fewer than 10 matches or 5 wins all time
-    if (player.validMatches < PLAYER_MINIMUM_GAMES_REQUIRED) {
+    if (player.validMatchesCount < PLAYER_MINIMUM_GAMES_REQUIRED) {
         return "Not enough games played";
     } else if (player.wins < PLAYER_MINIMUM_WINS_REQUIRED) {
         return "Not enough wins";

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -8,7 +8,7 @@ export function getWinRatePercentage(winCount: number, totalCount: number) {
 export function getAverageWinTurn(player: Player) {
     // Early exit conditions
     // Don't show if player has fewer than 10 matches or 5 wins all time
-    if (player.matches.length < PLAYER_MINIMUM_GAMES_REQUIRED) {
+    if (player.validMatches < PLAYER_MINIMUM_GAMES_REQUIRED) {
         return "Not enough games played";
     } else if (player.wins < PLAYER_MINIMUM_WINS_REQUIRED) {
         return "Not enough wins";

--- a/src/types/domain/Commander.ts
+++ b/src/types/domain/Commander.ts
@@ -7,11 +7,13 @@ export type Commander = {
      */
     matches: string[];
     /**
-     * Number of games we want to take into account when calculating stats (i.e. 4 player pods).
+     * Number of matches we want to take into account when calculating stats.
+     * This number is determined after removing all games that don't match the minimum
+     * criteria to be considered for stats (for example: having the correct number of players).
      */
     validMatchesCount: number;
     /**
-     * The number of wins across all this player's VALID matches (i.e. 4 player pods).
+     * Valid matches are those determined by some minimum criteria. For example: having the correct number of players.
      */
     wins: number;
 };

--- a/src/types/domain/Commander.ts
+++ b/src/types/domain/Commander.ts
@@ -6,5 +6,6 @@ export type Commander = {
      * A collection of match IDs of matches that the commander is played in
      */
     matches: string[];
+    validMatches: number; // Games we want to take into account when calculating stats (usually 4 player pod)
     wins: number;
 };

--- a/src/types/domain/Commander.ts
+++ b/src/types/domain/Commander.ts
@@ -3,9 +3,15 @@ export type Commander = {
     name: string;
     colorIdentity: string[];
     /**
-     * A collection of match IDs of matches that the commander is played in
+     * A collection of match IDs of matches that the commander is played in.
      */
     matches: string[];
-    validMatches: number; // Games we want to take into account when calculating stats (usually 4 player pod)
+    /**
+     * Number of games we want to take into account when calculating stats (i.e. 4 player pods).
+     */
+    validMatchesCount: number;
+    /**
+     * The number of wins across all this player's VALID matches (i.e. 4 player pods).
+     */
     wins: number;
 };

--- a/src/types/domain/Player.ts
+++ b/src/types/domain/Player.ts
@@ -3,6 +3,7 @@ import { Match } from "./Match";
 export type Player = {
     name: string;
     matches: Match[];
+    validMatches: number; // Games we want to take into account when calculating stats (usually 4 player pod)
     wins: number;
     /**
      * A dictionary representing the colors of the commanders the player has played.

--- a/src/types/domain/Player.ts
+++ b/src/types/domain/Player.ts
@@ -2,8 +2,17 @@ import { Match } from "./Match";
 
 export type Player = {
     name: string;
+    /**
+     * A collection of Match objects that the player has participated in. This includes all matches regardless of their validity.
+     */
     matches: Match[];
-    validMatches: number; // Games we want to take into account when calculating stats (usually 4 player pod)
+    /**
+     * Number of games we want to take into account when calculating stats (i.e. 4 player pods).
+     */
+    validMatchesCount: number;
+    /**
+     * The number of wins across all this player's VALID matches (i.e. 4 player pods).
+     */
     wins: number;
     /**
      * A dictionary representing the colors of the commanders the player has played.

--- a/src/types/domain/Player.ts
+++ b/src/types/domain/Player.ts
@@ -7,7 +7,9 @@ export type Player = {
      */
     matches: Match[];
     /**
-     * Number of games we want to take into account when calculating stats (i.e. 4 player pods).
+     * Number of matches we want to take into account when calculating stats.
+     * This number is determined after removing all games that don't match the minimum
+     * criteria to be considered for stats (for example: having the correct number of players).
      */
     validMatchesCount: number;
     /**


### PR DESCRIPTION
In dictionaryUtils.ts created a function that filters matches by the seat number. It takes in the matches as an array, and a number. The number is seat count _to keep_, e.g. you want only matches with 5 players you input 5. Applied this function to:
- Matches to Players
- Matches to Commanders

Additionally in utils.ts created a very simple check for the same thing but with a fixed value so that the average win turn method only eats games with 4 players.

The reason for this edit is to prevent inflated win percentages. EV for 4 seats is 25%, EV for 3 seats is 33% => more games with fewer players leads to a higher win percentage.