### PR TITLE
Add fixes for redirect uri and initialization of favorite commander

### DIFF
--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -25,8 +25,9 @@ import { UserSelectors } from "../../redux/user/userSelectors";
 import { routes } from "../../navigation/routes";
 import { FF_IS_LOGIN_ENABLED } from "../../services/featureFlagService";
 import { LoginModal } from "../auth/LoginModal";
-import { SettingsMenuItem } from "../auth/SettingsMenuItem";
+import { SettingsMenuItem } from "../auth/SettingsModal";
 import { ProfileService } from "../../services/ProfileService";
+import { getDiscordLoginEndpoint } from "../../services/DiscordService";
 
 interface HeaderProps extends FlexProps {
     onProfileIconClick: () => void;
@@ -94,7 +95,7 @@ export const Header = ({ onProfileIconClick, ...rest }: HeaderProps) => {
     }, [dispatch]);
 
     const signIn = () => {
-        window.location.href = `https://discord.com/oauth2/authorize?response_type=token&client_id=${"1163345338376138773"}&state=15773059ghq9183habn&scope=identify`;
+        window.location.href = getDiscordLoginEndpoint();
     };
 
     const signOut = () => {

--- a/src/services/DiscordService.ts
+++ b/src/services/DiscordService.ts
@@ -6,6 +6,11 @@ import { AuthSelectors } from "../redux/auth/authSelectors";
 import { UserAction } from "../redux/user/userActions";
 import { UserSelectors } from "../redux/user/userSelectors";
 
+export const getDiscordLoginEndpoint = () => {
+    const redirectUri = encodeURIComponent("http://" + window.location.host + "/toski");
+    return `https://discord.com/api/oauth2/authorize?client_id=1163345338376138773&redirect_uri=${redirectUri}&response_type=token&scope=identify`;
+};
+
 const useCurrentUserInfo = () => {
     const dispatch = useDispatch();
 


### PR DESCRIPTION
I didn't realize that you had to specify the redirect URI as part of the discord login url, so I'm adding that. It takes the hostname and applies some light modifications to it to pass it there.

I also realized the settings modal never gets unmounted since it is part of the header basically, and the visiblity is toggled on/off. Hence, I am now doing some light hydration of the modal when it appears, but we need to better handle this moving forward.