### PR TITLE
bug fix to dictutils valid match count and wins

### DIFF
--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -105,8 +105,10 @@ export function matchesToCommanderHelper(
                 } else {
                     // since this commander exists, update the currentMatch count
                     playedCommanderDictionary[potentialCommanderObj.id].matches.push(currentMatch.id);
-                    if (player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
-                        playedCommanderDictionary[potentialCommanderObj.id].wins++;
+                    if (currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
+                        if(player.rank === "1") {
+                            playedCommanderDictionary[potentialCommanderObj.id].wins++;
+                        }
                         playedCommanderDictionary[potentialCommanderObj.id].validMatchesCount++;
                     }
                 }
@@ -172,9 +174,11 @@ export function matchesToPlayersHelper(
                 } else {
                     // since this player exists, update the currentMatch count
                     playerDictionary[player.name].matches.push(currentMatch);
-                    if (player.rank === "1" && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
+                    if (currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
+                        if (player.rank === "1") {
+                            playerDictionary[player.name].wins++;
+                        }
                         playerDictionary[player.name].validMatchesCount++;
-                        playerDictionary[player.name].wins++;
                     }
 
                     // compute the players color profile


### PR DESCRIPTION
bug fix: wins and valid games were incremented at the same speed making everyone win a lot

cause: missing if statement that was supposed to increment validMatchesCount - and wins only IF the player was a winner. it did both at the same time.