### PR TITLE
Replace usage of matches.length with "validMatchCount"

### DIFF
--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -19,6 +19,7 @@ import { MatchPlacementBarChart } from "./MatchPlacementBarChart";
 import { primaryColor } from "../../themes/acorn";
 import { topPlayersColumns } from "../dataVisualizations/columnHelpers/topPlayersColumnHelper";
 import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
+import { getWinRatePercentage } from "../../logic/utils";
 
 export async function loader(data: { params: any }) {
     return data.params.commanderId;
@@ -183,7 +184,7 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                     >
                         {`Winrate: ${
                             commander.validMatchesCount > 0
-                                ? Math.round((commander.wins / commander.validMatchesCount) * 100)
+                                ? getWinRatePercentage(commander.wins, commander.validMatchesCount)
                                 : 0
                         }%`}
                     </Text>

--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useState } from "react";
 import { useSelector } from "react-redux";
 import { useLoaderData, useNavigate } from "react-router-dom";
 import { Flex, Heading, Image, Input, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from "@chakra-ui/react";
-
 import { AppState } from "../../redux/rootReducer";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
 import { Loading } from "../Loading";
@@ -46,10 +45,14 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
         [setSearchInput]
     );
 
+    // Get all matches to display in Match History of the Commander Overview
     const matches = useSelector((state: AppState) =>
         StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)
     );
-    const matchesFilteredByPlayerCount = filterMatchesByPlayerCount(useSelector((state: AppState) =>
+
+    // Get matches filtered by player count to use in statistical calculations
+    // These matches are considered "valid" because they all have the same number of players
+    const validMatches = filterMatchesByPlayerCount(useSelector((state: AppState) =>
     StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)), NUMBER_OF_PLAYERS_FOR_VALID_MATCH
     );
     const commanderPlayers: Player[] = useSelector((state: AppState) =>
@@ -80,7 +83,7 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
 
     let numberOfWins = 0;
 
-    const winratePerMatch = matchesFilteredByPlayerCount.map((match: Match, index: number) => {
+    const winratePerMatch = validMatches.map((match: Match, index: number) => {
         const winningPlayer = match.players.find((player: MatchPlayer) => player.rank === "1");
 
         let currentWinRate = 0;
@@ -102,7 +105,7 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
     });
 
     const tooltipTitleCallback = (item: TooltipItem<"line">[]) => {
-        return `Match Id: ${matches[item[0].dataIndex].id}`;
+        return `Match ID: ${validMatches[item[0].dataIndex].id}`;
     };
     const tooltipLabelCallback = (item: TooltipItem<"line">) => {
         return `Winrate: ${item.formattedValue}%`;
@@ -239,7 +242,7 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                     </TabPanel>
                     <TabPanel>
                         <Flex flexDirection={"column"} justifyContent={"center"} alignItems={"center"} padding="8px">
-                            {matchesFilteredByPlayerCount.length >= COMMANDER_MINIMUM_GAMES_REQUIRED ? (
+                            {validMatches.length >= COMMANDER_MINIMUM_GAMES_REQUIRED ? (
                                 <LineGraph
                                     dataLabel={"Winrate"}
                                     data={winratePerMatch}

--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -14,7 +14,7 @@ import { Match } from "../../types/domain/Match";
 import { MatchPlayer } from "../../types/domain/MatchPlayer";
 import { LineGraph } from "../dataVisualizations/LineGraph";
 import { Player } from "../../types/domain/Player";
-import { COMMANDER_MINIMUM_GAMES_REQUIRED } from "../constants";
+import { COMMANDER_MINIMUM_GAMES_REQUIRED, NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../constants";
 import { DatePicker } from "../common/DatePicker";
 import { MatchPlacementBarChart } from "./MatchPlacementBarChart";
 import { primaryColor } from "../../themes/acorn";
@@ -50,7 +50,7 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
         StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)
     );
     const matchesFilteredByPlayerCount = filterMatchesByPlayerCount(useSelector((state: AppState) =>
-    StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)), 4
+    StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)), NUMBER_OF_PLAYERS_FOR_VALID_MATCH
     );
     const commanderPlayers: Player[] = useSelector((state: AppState) =>
         StatsSelectors.getPlayersByCommanderName(state, commander ? commander.name : "", dateFilter)

--- a/src/components/commanderOverview/CommanderOverview.tsx
+++ b/src/components/commanderOverview/CommanderOverview.tsx
@@ -46,7 +46,7 @@ export const CommanderOverview = React.memo(function MatchHistory() {
     let commandersArray = commanders.sort((a: Commander, b: Commander) => a.name.localeCompare(b.name));
     if (isFiltered && allCommanders) {
         commandersArray = commandersArray.filter(
-            (value: Commander) => allCommanders[value.id].matches.length >= COMMANDER_MINIMUM_GAMES_REQUIRED
+            (value: Commander) => allCommanders[value.id].validMatchesCount >= COMMANDER_MINIMUM_GAMES_REQUIRED
         );
     }
     if (searchInput.length > 0 && allCommanders) {

--- a/src/components/commanderOverview/MatchPlacementBarChart.tsx
+++ b/src/components/commanderOverview/MatchPlacementBarChart.tsx
@@ -9,7 +9,7 @@ import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../constants";
 import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
 
 export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart({
-    matches: matches,
+    matches,
     commanderName
 }: {
     matches: Match[];

--- a/src/components/commanderOverview/MatchPlacementBarChart.tsx
+++ b/src/components/commanderOverview/MatchPlacementBarChart.tsx
@@ -22,7 +22,7 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
     const validMatches = filterMatchesByPlayerCount(matches, NUMBER_OF_PLAYERS_FOR_VALID_MATCH);
 
     if (validMatches.length === 0) {
-        return <Text textAlign={"center"}>No valid matches to display.</Text>;
+        return <Text textAlign={"center"}>No valid matches</Text>;
     }
 
     for (const match of validMatches) {

--- a/src/components/commanderOverview/MatchPlacementBarChart.tsx
+++ b/src/components/commanderOverview/MatchPlacementBarChart.tsx
@@ -5,9 +5,11 @@ import { Flex, Heading, Text } from "@chakra-ui/react";
 import { Loading } from "../Loading";
 import { Match } from "../../types/domain/Match";
 import { BarGraph } from "../dataVisualizations/BarGraph";
+import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../constants";
+import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
 
 export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart({
-    matches,
+    matches: matches,
     commanderName
 }: {
     matches: Match[];
@@ -16,10 +18,14 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
     if (matches === undefined) {
         return <Loading text="" />;
     }
-
     const matchPlacementDictionary: { [rank: string]: number } = {};
+    const validMatches = filterMatchesByPlayerCount(matches, NUMBER_OF_PLAYERS_FOR_VALID_MATCH);
 
-    for (const match of matches) {
+    if (validMatches.length === 0) {
+        return <Text textAlign={"center"}>No valid matches to display.</Text>;
+    }
+
+    for (const match of validMatches) {
         for (const player of match.players) {
             for (const commander of player.commanders) {
                 if (commander === commanderName) {
@@ -54,7 +60,7 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
                 data={matchPlacementData}
                 tooltipTitleCallback={tooltipTitleCallback}
                 tooltipLabelCallback={tooltipLabelCallback}
-                maxY={matches.length}
+                maxY={validMatches.length}
             />
         </Flex>
     );

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -1,8 +1,9 @@
 export const PLAYER_MINIMUM_GAMES_REQUIRED = 10;
 export const PLAYER_MINIMUM_WINS_REQUIRED = 5; // Used for average win turn
 export const COMMANDER_MINIMUM_GAMES_REQUIRED = 5;
-export const NEW_PLAYER_HIGHLIGHT_DAYS = 7; // Used for highlighting newly qualified players in the playerOverview list
+export const NEW_PLAYER_HIGHLIGHT_DAYS = 30; // Used for highlighting newly qualified players for N days
 export const NUMBER_OF_PLAYERS_FOR_VALID_MATCH = 4; // Used for filtering out matches without 4 players
+export const PLAYER_MAXIMUM_GAMES_AS_NEW_PLAYER = 15; // Used for defining what constitutes a new player; below this they get highlighted
 
 export const MTG_COLORS: { name: string; id: string; rgb: string }[] = [
     { name: "Black", id: "B", rgb: "rgb(166, 159, 157)" },

--- a/src/components/dataVisualizations/columnHelpers/commanderMatchupsColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderMatchupsColumnHelper.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Image } from "@chakra-ui/react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
-
+import { getWinRatePercentage } from "../../../logic/utils";
 import { commanderList } from "../../../services/commanderList";
 
 export type CommanderMatchupItem = {
@@ -40,12 +40,12 @@ export const commanderMatchupsColumns: ColumnDef<CommanderMatchupItem, any>[] = 
         cell: (info) => info.row.original.winCount,
         header: () => <span>Wins Against</span>
     }),
-    columnHelper.accessor((row) => (row.matchCount > 0 ? Math.round((row.winCount / row.matchCount) * 100) : 0), {
+    columnHelper.accessor((row) => (row.matchCount > 0 ? getWinRatePercentage(row.winCount, row.matchCount) : 0), {
         id: "winrate",
         cell: (info) =>
             info.row.original.matchCount > 0
-                ? `${Math.round((info.row.original.winCount / info.row.original.matchCount) * 100)}%`
-                : `N/A`,
+                ? `${getWinRatePercentage(info.row.original.winCount, info.row.original.matchCount)}%`
+                : `N/A`, // This should never happen since matchCount is checked to be >0
         header: () => <span>Winrate Against</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/commanderMatchupsColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderMatchupsColumnHelper.tsx
@@ -45,7 +45,7 @@ export const commanderMatchupsColumns: ColumnDef<CommanderMatchupItem, any>[] = 
         cell: (info) =>
             info.row.original.matchCount > 0
                 ? `${Math.round((info.row.original.winCount / info.row.original.matchCount) * 100)}%`
-                : `0%`,
+                : `N/A`,
         header: () => <span>Winrate Against</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Image } from "@chakra-ui/react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
-
+import { getWinRatePercentage } from "../../../logic/utils";
 import { commanderList } from "../../../services/commanderList";
 import { Commander } from "../../../types/domain/Commander";
 
@@ -34,11 +34,11 @@ export const commanderOverviewColumns: ColumnDef<Commander, any>[] = [
         cell: (info) => info.row.original.wins,
         header: () => <span>Wins</span>
     }),
-    columnHelper.accessor((row) => (row.validMatchesCount > 0 ? Math.round((row.wins / row.validMatchesCount) * 100) : 0), {
+    columnHelper.accessor((row) => (row.validMatchesCount > 0 ? getWinRatePercentage(row.wins, row.validMatchesCount) : 0), {
         id: "winrate",
         cell: (info) =>
             info.row.original.validMatchesCount > 0 // A commander may exist with 0 valid matches - prevent division by 0
-                ? `${Math.round((info.row.original.wins / info.row.original.validMatchesCount) * 100)}%`
+                ? `${getWinRatePercentage(info.row.original.wins, info.row.original.validMatchesCount)}%`
                 : `N/A`, // Display N/A if the commander has no valid matches
         header: () => <span>Winrate</span>
     })

--- a/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
@@ -37,9 +37,9 @@ export const commanderOverviewColumns: ColumnDef<Commander, any>[] = [
     columnHelper.accessor((row) => (row.validMatchesCount > 0 ? Math.round((row.wins / row.validMatchesCount) * 100) : 0), {
         id: "winrate",
         cell: (info) =>
-            info.row.original.validMatchesCount > 0
+            info.row.original.validMatchesCount > 0 // A commander may exist with 0 valid matches - prevent division by 0
                 ? `${Math.round((info.row.original.wins / info.row.original.validMatchesCount) * 100)}%`
-                : `N/A`,
+                : `N/A`, // Display N/A if the commander has no valid matches
         header: () => <span>Winrate</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
@@ -24,9 +24,9 @@ export const commanderOverviewColumns: ColumnDef<Commander, any>[] = [
         },
         header: () => <span>Name</span>
     }),
-    columnHelper.accessor((row) => row.matches.length, {
+    columnHelper.accessor((row) => row.validMatchesCount, {
         id: "gameCount",
-        cell: (info) => info.row.original.matches.length,
+        cell: (info) => info.row.original.validMatchesCount,
         header: () => <span>Game Count</span>
     }),
     columnHelper.accessor((row) => row.wins, {
@@ -34,12 +34,12 @@ export const commanderOverviewColumns: ColumnDef<Commander, any>[] = [
         cell: (info) => info.row.original.wins,
         header: () => <span>Wins</span>
     }),
-    columnHelper.accessor((row) => (row.matches.length > 0 ? Math.round((row.wins / row.matches.length) * 100) : 0), {
+    columnHelper.accessor((row) => (row.validMatchesCount > 0 ? Math.round((row.wins / row.validMatchesCount) * 100) : 0), {
         id: "winrate",
         cell: (info) =>
-            info.row.original.matches.length > 0
-                ? `${Math.round((info.row.original.wins / info.row.original.matches.length) * 100)}%`
-                : `0%`,
+            info.row.original.validMatchesCount > 0
+                ? `${Math.round((info.row.original.wins / info.row.original.validMatchesCount) * 100)}%`
+                : `N/A`,
         header: () => <span>Winrate</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/playerMatchupsColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/playerMatchupsColumnHelper.tsx
@@ -1,4 +1,5 @@
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { getWinRatePercentage } from "../../../logic/utils";
 
 export type PlayerMatchupItem = {
     name: string;
@@ -24,12 +25,12 @@ export const playerMatchupsColumns: ColumnDef<PlayerMatchupItem, any>[] = [
         cell: (info) => info.row.original.winCount,
         header: () => <span>Wins Against</span>
     }),
-    columnHelper.accessor((row) => (row.matchCount > 0 ? Math.round((row.winCount / row.matchCount) * 100) : 0), {
+    columnHelper.accessor((row) => (row.matchCount > 0 ? getWinRatePercentage(row.winCount, row.matchCount) : 0), {
         id: "winrate",
         cell: (info) =>
             info.row.original.matchCount > 0
-                ? `${Math.round((info.row.original.winCount / info.row.original.matchCount) * 100)}%`
-                : `N/A`,
+                ? `${getWinRatePercentage(info.row.original.winCount, info.row.original.matchCount)}%`
+                : `N/A`, // This should never happen since matchCount is checked to be >0
         header: () => <span>Winrate Against</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/playerMatchupsColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/playerMatchupsColumnHelper.tsx
@@ -29,7 +29,7 @@ export const playerMatchupsColumns: ColumnDef<PlayerMatchupItem, any>[] = [
         cell: (info) =>
             info.row.original.matchCount > 0
                 ? `${Math.round((info.row.original.winCount / info.row.original.matchCount) * 100)}%`
-                : `0%`,
+                : `N/A`,
         header: () => <span>Winrate Against</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/playerOverviewColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/playerOverviewColumnHelper.tsx
@@ -25,7 +25,7 @@ export const playerOverviewColumns: ColumnDef<Player, any>[] = [
     }),
     columnHelper.accessor((row) => row.matches, {
         id: "gameCount",
-        cell: (info) => info.row.original.matches.length,
+        cell: (info) => info.row.original.validMatchesCount,
         header: () => <span>Game Count</span>
     }),
     columnHelper.accessor((row) => row.wins, {
@@ -33,12 +33,12 @@ export const playerOverviewColumns: ColumnDef<Player, any>[] = [
         cell: (info) => info.row.original.wins,
         header: () => <span>Wins</span>
     }),
-    columnHelper.accessor((row) => (row.matches.length > 0 ? getWinRatePercentage(row.wins, row.matches.length) : 0), {
+    columnHelper.accessor((row) => (row.validMatchesCount > 0 ? getWinRatePercentage(row.wins, row.validMatchesCount) : 0), {
         id: "winrate",
         cell: (info) =>
-            info.row.original.matches.length > 0
-                ? `${getWinRatePercentage(info.row.original.wins, info.row.original.matches.length)}%`
-                : `0%`,
+            info.row.original.validMatchesCount > 0
+                ? `${getWinRatePercentage(info.row.original.wins, info.row.original.validMatchesCount)}%`
+                : `N/A`,
         header: () => <span>Winrate</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/topPlayersColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/topPlayersColumnHelper.tsx
@@ -21,7 +21,7 @@ export const topPlayersColumns: ColumnDef<Player, any>[] = [
     }),
     columnHelper.accessor((row) => row.matches, {
         id: "gameCount",
-        cell: (info) => info.row.original.matches.length,
+        cell: (info) => info.row.original.validMatchesCount,
         header: () => <span>Game Count</span>
     }),
     columnHelper.accessor((row) => row.wins, {
@@ -29,12 +29,12 @@ export const topPlayersColumns: ColumnDef<Player, any>[] = [
         cell: (info) => info.row.original.wins,
         header: () => <span>Wins</span>
     }),
-    columnHelper.accessor((row) => (row.matches.length > 0 ? getWinRatePercentage(row.wins, row.matches.length) : 0), {
+    columnHelper.accessor((row) => (row.validMatchesCount > 0 ? getWinRatePercentage(row.wins, row.validMatchesCount) : 0), {
         id: "winrate",
         cell: (info) =>
-            info.row.original.matches.length > 0
-                ? `${getWinRatePercentage(info.row.original.wins, info.row.original.matches.length)}%`
-                : `0%`,
+            info.row.original.validMatchesCount > 0
+                ? `${getWinRatePercentage(info.row.original.wins, info.row.original.validMatchesCount)}%`
+                : `N/A`,
         header: () => <span>Winrate</span>
     })
 ];

--- a/src/components/playerOverview/CommanderHistoryTable.tsx
+++ b/src/components/playerOverview/CommanderHistoryTable.tsx
@@ -21,7 +21,7 @@ export const CommanderHistoryTable = React.memo(function CommanderHistoryTable({
     const playedCommanders: Commander[] = useSelector((state: AppState) =>
         StatsSelectors.getCommandersByPlayerName(state, playerId ? playerId : "", dateFilter)
     );
-    playedCommanders.sort((a: Commander, b: Commander) => b.matches.length - a.matches.length);
+    playedCommanders.sort((a: Commander, b: Commander) => b.validMatchesCount - a.validMatchesCount);
 
     return (
         <SortableTable

--- a/src/components/playerOverview/MatchPlacementBarChart.tsx
+++ b/src/components/playerOverview/MatchPlacementBarChart.tsx
@@ -23,8 +23,8 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
     const matchPlacementDictionary: { [rank: string]: number } = {};
     const validMatches = filterMatchesByPlayerCount(matches, NUMBER_OF_PLAYERS_FOR_VALID_MATCH);
 
-    if (validMatches === undefined) {
-        return <Text textAlign={"center"}>No valid matches to display.</Text>
+    if (validMatches.length === 0) {
+        return <Text textAlign={"center"}>No valid matches</Text>
     }
 
     for (const match of validMatches) {

--- a/src/components/playerOverview/MatchPlacementBarChart.tsx
+++ b/src/components/playerOverview/MatchPlacementBarChart.tsx
@@ -5,7 +5,7 @@ import { Flex, Heading, Text } from "@chakra-ui/react";
 import { Loading } from "../Loading";
 import { Match } from "../../types/domain/Match";
 import { BarGraph } from "../dataVisualizations/BarGraph";
-import { PLAYER_MINIMUM_GAMES_REQUIRED } from "../constants";
+import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH, PLAYER_MINIMUM_GAMES_REQUIRED } from "../constants";
 import { InsufficientData } from "./InsufficientData";
 import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
 
@@ -21,9 +21,9 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
     }
 
     const matchPlacementDictionary: { [rank: string]: number } = {};
-    const validMatches = filterMatchesByPlayerCount(matches, 4);
+    const validMatches = filterMatchesByPlayerCount(matches, NUMBER_OF_PLAYERS_FOR_VALID_MATCH);
 
-    if (filterMatchesByPlayerCount(validMatches, 4) === undefined) {
+    if (validMatches === undefined) {
         return <Text textAlign={"center"}>No valid matches to display.</Text>
     }
 

--- a/src/components/playerOverview/MatchPlacementBarChart.tsx
+++ b/src/components/playerOverview/MatchPlacementBarChart.tsx
@@ -7,6 +7,7 @@ import { Match } from "../../types/domain/Match";
 import { BarGraph } from "../dataVisualizations/BarGraph";
 import { PLAYER_MINIMUM_GAMES_REQUIRED } from "../constants";
 import { InsufficientData } from "./InsufficientData";
+import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
 
 export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart({
     matches,
@@ -20,8 +21,13 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
     }
 
     const matchPlacementDictionary: { [rank: string]: number } = {};
+    const validMatches = filterMatchesByPlayerCount(matches, 4);
 
-    for (const match of matches) {
+    if (filterMatchesByPlayerCount(validMatches, 4) === undefined) {
+        return <Text textAlign={"center"}>No valid matches to display.</Text>
+    }
+
+    for (const match of validMatches) {
         for (const player of match.players) {
             if (player.name === playerId) {
                 if (matchPlacementDictionary[player.rank] === undefined) {
@@ -49,13 +55,13 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
     return (
         <Flex flexDirection={"column"} justifyContent={"center"} alignItems={"center"} padding="8px">
             <Heading size="md">Match Placements</Heading>
-            {matches.length >= PLAYER_MINIMUM_GAMES_REQUIRED ? (
+            {validMatches.length >= PLAYER_MINIMUM_GAMES_REQUIRED ? (
                 <BarGraph
                     dataLabel={"Match Placement Count"}
                     data={matchPlacementData}
                     tooltipTitleCallback={tooltipTitleCallback}
                     tooltipLabelCallback={tooltipLabelCallback}
-                    maxY={matches.length}
+                    maxY={validMatches.length}
                 />
             ) : (
                 <InsufficientData description={"Not enough matches"} />

--- a/src/components/playerOverview/PlayerOverview.tsx
+++ b/src/components/playerOverview/PlayerOverview.tsx
@@ -40,7 +40,7 @@ export const PlayerOverview = React.memo(function MatchHistory() {
     let playersArray = players.sort((a: Player, b: Player) => a.name.localeCompare(b.name));
     if (isFiltered) {
         playersArray = playersArray.filter(
-            (value: Player) => allPlayers[value.name].matches.length >= PLAYER_MINIMUM_GAMES_REQUIRED
+            (value: Player) => allPlayers[value.name].validMatchesCount >= PLAYER_MINIMUM_GAMES_REQUIRED
         );
     }
 

--- a/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
@@ -89,7 +89,7 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
                     borderLeftWidth={1}
                     borderRightWidth={1}
                     borderBottomWidth={1}
-                >{`Games played: ${player.matches.length}`}</Text>
+                >{`Games played: ${player.validMatchesCount}`}</Text>
                 <Text
                     paddingLeft={"16px"}
                     paddingRight={"16px"}

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -27,7 +27,7 @@ export function filterMatchesByPlayerCount(matches: Match[], playerCount: number
 /**
  * Given a collection of Matches, filters them to matches after a certain date.
  * Optionally, provide an end date as well.
- * @param matches
+ * @param matches Matches to consider. Only filters by date! Not validness
  * @param startDate
  * @param endDate
  * @returns
@@ -52,7 +52,7 @@ export function filterMatchesByDate(matches: Match[], startDate?: Date, endDate?
 
 /**
  * Given a collection of matches, create a dictionary of commanders with optional filters
- * @param matches The collection of matches to build the dictionary from
+ * @param matches The collection of matches to build the dictionary from. For stats it filters out matches with incorrect player counts
  * @param playerId An optional player name to filter the commanders by (will only return commanders the player has played)
  * @returns A dictionary of commanders keyed by commanderId
  */
@@ -120,7 +120,7 @@ export function matchesToCommanderHelper(
 
 /**
  * Given a collection of matches, create a dictionary of players with optional filters
- * @param matches The collection of matches to build the dictionary from
+ * @param matches The collection of matches to build the dictionary from. For stats it filters out matches with incorrect player counts
  * @param commanderName An optional commander name to filter the users by (the user must have played this commander)
  * @returns A dictionary of player keyed by playerId
  */

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -27,7 +27,8 @@ export function filterMatchesByPlayerCount(matches: Match[], playerCount: number
 /**
  * Given a collection of Matches, filters them to matches after a certain date.
  * Optionally, provide an end date as well.
- * @param matches Matches to consider. Only filters by date! Not validness
+ * No other checks than provided dates. Does not consider the validness of a game, for instance.
+ * @param matches Matches to consider
  * @param startDate
  * @param endDate
  * @returns
@@ -51,8 +52,10 @@ export function filterMatchesByDate(matches: Match[], startDate?: Date, endDate?
 }
 
 /**
- * Given a collection of matches, create a dictionary of commanders with optional filters
- * @param matches The collection of matches to build the dictionary from. For stats it filters out matches with incorrect player counts
+ * Given a collection of matches, create a dictionary of players with optional filters
+ * where the stats of those players are computed only using valid matches
+ * (as determined by the required number of players in the match).
+ * @param matches The collection of matches to build the dictionary from
  * @param playerId An optional player name to filter the commanders by (will only return commanders the player has played)
  * @returns A dictionary of commanders keyed by commanderId
  */

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -1,14 +1,28 @@
 import {
     NEW_PLAYER_HIGHLIGHT_DAYS,
+    NUMBER_OF_PLAYERS_FOR_VALID_MATCH,
+    PLAYER_MAXIMUM_GAMES_AS_NEW_PLAYER,
     PLAYER_MINIMUM_GAMES_REQUIRED,
     PLAYER_MINIMUM_WINS_REQUIRED
 } from "../components/constants";
 import { Player } from "../types/domain/Player";
 
+
+/**
+ * Gets the win rate as a percentage (number, without the "%").
+ * @param winCount Wins - most likely valid wins.
+ * @param totalCount Number of matches to consider - most likely valid matches.
+ * @returns A whole number from 0 to 100.
+ */
 export function getWinRatePercentage(winCount: number, totalCount: number) {
     return totalCount > 0 ? Math.round((winCount / totalCount) * 100) : 0;
 }
 
+/**
+ * Gets the average win turn of a player.
+ * @param player Has to be type Player. Filters out automatically matches that don't meet the player count requirement.
+ * @returns A number rounded up to one decimal.
+ */
 export function getAverageWinTurn(player: Player) {
     // Early exit conditions
     // Don't show if player has fewer than 10 matches or 5 wins all time
@@ -23,8 +37,9 @@ export function getAverageWinTurn(player: Player) {
 
     // Get win turn for every match win
     for (const match of player.matches) {
-        if (player.name === match.winner && match.players.length == 4) {
-            // Exclude wins without turns data or fewer than 4 players
+        // Exclude matches where player isn't a winner and player count requirement isn't filled
+        if (player.name === match.winner && match.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
+            // Exclude wins without turns data
             if (Number(match.numberOfTurns) > 0) {
                 winTurns.push(Number(match.numberOfTurns));
             }
@@ -41,13 +56,18 @@ export function getAverageWinTurn(player: Player) {
     return average.toFixed(1);
 }
 
+/**
+ * Used to define what highlights a newly qualified player.
+ * @param player 
+ * @returns True / False
+ */
 export function isNewlyQualifiedPlayer(player: Player) {
     const dateOffset = new Date();
     dateOffset.setDate(dateOffset.getDate() - NEW_PLAYER_HIGHLIGHT_DAYS);
     const lastIndex = player.validMatchesCount - 1;
     if (
         PLAYER_MINIMUM_GAMES_REQUIRED <= player.validMatchesCount &&
-        player.validMatchesCount <= 15 &&
+        player.validMatchesCount <= PLAYER_MAXIMUM_GAMES_AS_NEW_PLAYER &&
         dateOffset < player.matches[lastIndex].date
     ) {
         return true;

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -19,8 +19,8 @@ export function getWinRatePercentage(winCount: number, totalCount: number) {
 }
 
 /**
- * Gets the average win turn of a player.
- * @param player Has to be type Player. Filters out automatically matches that don't meet the player count requirement.
+ * Gets the average win turn of a player. Filters out automatically matches that don't meet the player count requirement.
+ * @param player Has to be type Player.
  * @returns A number rounded up to one decimal.
  */
 export function getAverageWinTurn(player: Player) {
@@ -57,9 +57,9 @@ export function getAverageWinTurn(player: Player) {
 }
 
 /**
- * Used to define what highlights a newly qualified player.
+ * Given a player returns whether they're considered to be a newcomer on the stats or not. Counts valid matches only.
  * @param player 
- * @returns True / False
+ * @returns
  */
 export function isNewlyQualifiedPlayer(player: Player) {
     const dateOffset = new Date();

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -44,10 +44,10 @@ export function getAverageWinTurn(player: Player) {
 export function isNewlyQualifiedPlayer(player: Player) {
     const dateOffset = new Date();
     dateOffset.setDate(dateOffset.getDate() - NEW_PLAYER_HIGHLIGHT_DAYS);
-    const lastIndex = player.matches.length - 1;
+    const lastIndex = player.validMatchesCount - 1;
     if (
-        PLAYER_MINIMUM_GAMES_REQUIRED <= player.matches.length &&
-        player.matches.length <= 15 &&
+        PLAYER_MINIMUM_GAMES_REQUIRED <= player.validMatchesCount &&
+        player.validMatchesCount <= 15 &&
         dateOffset < player.matches[lastIndex].date
     ) {
         return true;

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -10,8 +10,8 @@ import { Player } from "../types/domain/Player";
 
 /**
  * Gets the win rate as a percentage (number, without the "%").
- * @param winCount Wins - most likely valid wins.
- * @param totalCount Number of matches to consider - most likely valid matches.
+ * @param winCount Wins - use wins (valid wins).
+ * @param totalCount Number of matches to consider - use valid matches where appropriate.
  * @returns A whole number from 0 to 100.
  */
 export function getWinRatePercentage(winCount: number, totalCount: number) {

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -9,18 +9,19 @@ import { Player } from "../types/domain/Player";
 
 
 /**
- * Gets the win rate as a percentage (number, without the "%").
+ * Gets the win rate as a percentage. When calling this function make sure "winCount" and "totalCount" refer to the same set of matches.
  * @param winCount Wins - use wins (valid wins).
- * @param totalCount Number of matches to consider - use valid matches where appropriate.
- * @returns A whole number from 0 to 100.
+ * @param totalCount Number of matches to consider - use valid matches if appropriate.
+ * @returns An integer from 0 to 100.
  */
 export function getWinRatePercentage(winCount: number, totalCount: number) {
     return totalCount > 0 ? Math.round((winCount / totalCount) * 100) : 0;
 }
 
 /**
- * Gets the average win turn of a player. Filters out automatically matches that don't meet the player count requirement.
- * @param player Has to be type Player.
+ * Given a player gets the average win turn of a player.
+ * Filters out automatically matches that don't meet the player count requirement.
+ * @param player
  * @returns A number rounded up to one decimal.
  */
 export function getAverageWinTurn(player: Player) {
@@ -57,7 +58,7 @@ export function getAverageWinTurn(player: Player) {
 }
 
 /**
- * Given a player returns whether they're considered to be a newcomer on the stats or not. Counts valid matches only.
+ * Given a player returns whether they're considered to be a newly qualified player. Counts valid matches only.
  * @param player 
  * @returns
  */

--- a/src/types/service/MatchHistory/dataMappers.ts
+++ b/src/types/service/MatchHistory/dataMappers.ts
@@ -1,3 +1,4 @@
+import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../../../components/constants";
 import { Match } from "../../domain/Match";
 import { MatchPlayer } from "../../domain/MatchPlayer";
 import { SheetRow } from "./SheetData";
@@ -86,7 +87,7 @@ export function sheetRowToMatch(cell: SheetRow, id: string): Match {
 
 export function getPlayerWinRate(matches: Match[], playerName: string): { name: string; winR: number; loseR: number } {
     // Games counter
-    let games = 0;
+    let validMatches = 0;
 
     // Wins counter
     let wins = 0;
@@ -101,9 +102,9 @@ export function getPlayerWinRate(matches: Match[], playerName: string): { name: 
 
         // Loop through match players
         for (let j = 0; j < currentMatch.players.length; j++) {
-            // If player is in the game, increment game
-            if (playerName === currentMatch.players[j].name) {
-                games++;
+            // If player is in the game and the game had a valid number of players, increment game
+            if (playerName === currentMatch.players[j].name && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
+                validMatches++;
 
                 // If player won the game, increment wins
                 if (playerName === currentMatch.winner) {
@@ -113,5 +114,5 @@ export function getPlayerWinRate(matches: Match[], playerName: string): { name: 
         }
     }
 
-    return { name: playerName, winR: wins / games, loseR: 1 - wins / games };
+    return { name: playerName, winR: wins / validMatches, loseR: 1 - wins / validMatches };
 }

--- a/src/types/service/MatchHistory/dataMappers.ts
+++ b/src/types/service/MatchHistory/dataMappers.ts
@@ -85,6 +85,12 @@ export function sheetRowToMatch(cell: SheetRow, id: string): Match {
     };
 }
 
+/**
+ * Gets the winrate of a player from a collection of matches
+ * @param matches Automatically filtered to valid matches (by player count)
+ * @param playerName 
+ * @returns Player name, winrate and loserate as whole numbers from 0 to 100
+ */
 export function getPlayerWinRate(matches: Match[], playerName: string): { name: string; winR: number; loseR: number } {
     // Games counter
     let validMatches = 0;
@@ -102,6 +108,7 @@ export function getPlayerWinRate(matches: Match[], playerName: string): { name: 
 
         // Loop through match players
         for (let j = 0; j < currentMatch.players.length; j++) {
+
             // If player is in the game and the game had a valid number of players, increment game
             if (playerName === currentMatch.players[j].name && currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH) {
                 validMatches++;

--- a/src/types/service/MatchHistory/dataMappers.ts
+++ b/src/types/service/MatchHistory/dataMappers.ts
@@ -87,7 +87,7 @@ export function sheetRowToMatch(cell: SheetRow, id: string): Match {
 
 /**
  * Gets the winrate of a player from a collection of matches
- * @param matches Automatically filtered to valid matches (by player count)
+ * @param matches The collection of matches to determine the win rate against.
  * @param playerName 
  * @returns Player name, winrate and loserate as whole numbers from 0 to 100
  */

--- a/src/types/service/MatchHistory/dataMappers.ts
+++ b/src/types/service/MatchHistory/dataMappers.ts
@@ -86,13 +86,13 @@ export function sheetRowToMatch(cell: SheetRow, id: string): Match {
 }
 
 /**
- * Gets the winrate of a player from a collection of matches
- * @param matches The collection of matches to determine the win rate against.
+ * Gets the winrate of a player from a collection of matches without considering invalid matches.
+ * @param matches The collection of matches can be a mix of valid and invalid matches.
  * @param playerName 
- * @returns Player name, winrate and loserate as whole numbers from 0 to 100
+ * @returns Player name, winrate and loserate as whole numbers from 0 to 100.
  */
 export function getPlayerWinRate(matches: Match[], playerName: string): { name: string; winR: number; loseR: number } {
-    // Games counter
+    // Valid matches counter
     let validMatches = 0;
 
     // Wins counter


### PR DESCRIPTION
Bugfix.

Players had a non-valid number of players in some matches, namely, there are three player games in the data.

The aim of this fix is to convert all instances of "matches.length" to use the appropriate number, "validMatchCount".

As a consequence we have an accurate game count, win count, and win-% across the site.

There are still a couple of instances of "matches.length" left in the data but they're mostly related to displaying Match History which probably shouldn't be changed.

The changes also include a couple of failsafes for displaying data that doesn't exist and a naming convention change in win-% from "0%" for invalid match counts to "N/A" as that better reflects the reality. For example Aegar, the Freezing Flame has one game with three players and no four player games. It looks a little weird to say the win-% is "0%" when the game counter says 0 and that'd imply a division by 0.

Review of this code and the remaining instances of "matches.length" is requested.