### PR TITLE
Fix usage of win rate percentage in commander details

### DIFF
--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -53,8 +53,11 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
 
     // Get matches filtered by player count to use in statistical calculations
     // These matches are considered "valid" because they all have the same number of players
-    const validMatches = filterMatchesByPlayerCount(useSelector((state: AppState) =>
-    StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)), NUMBER_OF_PLAYERS_FOR_VALID_MATCH
+    const validMatches = filterMatchesByPlayerCount(
+        useSelector((state: AppState) =>
+            StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)
+        ),
+        NUMBER_OF_PLAYERS_FOR_VALID_MATCH
     );
     const commanderPlayers: Player[] = useSelector((state: AppState) =>
         StatsSelectors.getPlayersByCommanderName(state, commander ? commander.name : "", dateFilter)
@@ -184,9 +187,9 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                     >
                         {`Winrate: ${
                             commander.validMatchesCount > 0
-                                ? getWinRatePercentage(commander.wins, commander.validMatchesCount)
-                                : 0
-                        }%`}
+                                ? `${getWinRatePercentage(commander.wins, commander.validMatchesCount)}%`
+                                : "N/A"
+                        }`}
                     </Text>
                     <Text
                         paddingLeft={"16px"}

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -7,7 +7,6 @@ import {
 } from "../components/constants";
 import { Player } from "../types/domain/Player";
 
-
 /**
  * Gets the win rate as a percentage. When calling this function make sure "winCount" and "totalCount" refer to the same set of matches.
  * @param winCount
@@ -15,18 +14,22 @@ import { Player } from "../types/domain/Player";
  * @param decimalPlaces The number of decimal places to round to. Default is 0 decimal places. Use -1 to return the full float.
  * @returns Returns the winrate as a percentage from 0 to 100. Returns -1 if there's an error.
  */
-export function getWinRatePercentage(winCount: number, matchesCount: number, decimalPlaces: number | undefined = 0): number {
+export function getWinRatePercentage(
+    winCount: number,
+    matchesCount: number,
+    decimalPlaces: number | undefined = 0
+): number {
     if (winCount < 0 || matchesCount <= 0) {
         console.error("getWinRatePercentage winCount was negative or matchesCount was 0 or negative.");
         return -1;
-    } 
+    }
     if (!Number.isInteger(decimalPlaces)) {
         console.error("getWinRatePercentage tried to round by a non-integer.");
         return -1;
     }
     // Technically any negative integer will do, to get the float, but instructions tell you to use -1. This is intended.
-    const winrate = winCount / matchesCount * 100;
-    if (decimalPlaces < 0){
+    const winrate = (winCount / matchesCount) * 100;
+    if (decimalPlaces < 0) {
         return winrate;
     }
     // For lack of a better rounding function we take the full float winrate and multiply that
@@ -80,7 +83,7 @@ export function getAverageWinTurn(player: Player) {
 
 /**
  * Given a player returns whether they're considered to be a newly qualified player. Counts valid matches only.
- * @param player 
+ * @param player
  * @returns
  */
 export function isNewlyQualifiedPlayer(player: Player) {


### PR DESCRIPTION
The commander details should return N/A if there aren't enough valid matches to calculate a win rate.