### PR TITLE
Winrate & matchup table fixes

### DIFF
--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -188,7 +188,7 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                         {`Winrate: ${
                             commander.validMatchesCount > 0
                                 ? `${getWinRatePercentage(commander.wins, commander.validMatchesCount)}%`
-                                : "N/A"
+                                : "N/A" // Displays N/A if the commander has no valid matches
                         }`}
                     </Text>
                     <Text

--- a/src/components/dataVisualizations/columnHelpers/commanderMatchupsColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderMatchupsColumnHelper.tsx
@@ -45,7 +45,7 @@ export const commanderMatchupsColumns: ColumnDef<CommanderMatchupItem, any>[] = 
         cell: (info) =>
             info.row.original.matchCount > 0
                 ? `${getWinRatePercentage(info.row.original.winCount, info.row.original.matchCount)}%`
-                : `N/A`, // This should never happen since matchCount is checked to be >0
+                : `N/A`, // This shouldn't happen
         header: () => <span>Winrate Against</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
@@ -37,9 +37,9 @@ export const commanderOverviewColumns: ColumnDef<Commander, any>[] = [
     columnHelper.accessor((row) => (row.validMatchesCount > 0 ? getWinRatePercentage(row.wins, row.validMatchesCount) : 0), {
         id: "winrate",
         cell: (info) =>
-            info.row.original.validMatchesCount > 0 // A commander may exist with 0 valid matches - prevent division by 0
+            info.row.original.validMatchesCount > 0
                 ? `${getWinRatePercentage(info.row.original.wins, info.row.original.validMatchesCount)}%`
-                : `N/A`, // Display N/A if the commander has no valid matches
+                : `N/A`, // Displays N/A if the commander has no valid matches
         header: () => <span>Winrate</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/playerMatchupsColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/playerMatchupsColumnHelper.tsx
@@ -30,7 +30,7 @@ export const playerMatchupsColumns: ColumnDef<PlayerMatchupItem, any>[] = [
         cell: (info) =>
             info.row.original.matchCount > 0
                 ? `${getWinRatePercentage(info.row.original.winCount, info.row.original.matchCount)}%`
-                : `N/A`, // Displays N/A if the player has no valid matches
+                : `N/A`, // This shouldn't happen
         header: () => <span>Winrate Against</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/playerMatchupsColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/playerMatchupsColumnHelper.tsx
@@ -30,7 +30,7 @@ export const playerMatchupsColumns: ColumnDef<PlayerMatchupItem, any>[] = [
         cell: (info) =>
             info.row.original.matchCount > 0
                 ? `${getWinRatePercentage(info.row.original.winCount, info.row.original.matchCount)}%`
-                : `N/A`, // This should never happen since matchCount is checked to be >0
+                : `N/A`, // Displays N/A if the player has no valid matches
         header: () => <span>Winrate Against</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/playerOverviewColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/playerOverviewColumnHelper.tsx
@@ -38,7 +38,7 @@ export const playerOverviewColumns: ColumnDef<Player, any>[] = [
         cell: (info) =>
             info.row.original.validMatchesCount > 0
                 ? `${getWinRatePercentage(info.row.original.wins, info.row.original.validMatchesCount)}%`
-                : `N/A`,
+                : `N/A`, // Displays N/A if the player has no valid matches
         header: () => <span>Winrate</span>
     })
 ];

--- a/src/components/dataVisualizations/columnHelpers/topPlayersColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/topPlayersColumnHelper.tsx
@@ -34,7 +34,7 @@ export const topPlayersColumns: ColumnDef<Player, any>[] = [
         cell: (info) =>
             info.row.original.validMatchesCount > 0
                 ? `${getWinRatePercentage(info.row.original.wins, info.row.original.validMatchesCount)}%`
-                : `N/A`,
+                : `N/A`, // Displays N/A if the player has no valid matches
         header: () => <span>Winrate</span>
     })
 ];

--- a/src/components/playerOverview/CommanderMatchupsTable.tsx
+++ b/src/components/playerOverview/CommanderMatchupsTable.tsx
@@ -22,7 +22,7 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
 }) {
     const navigate = useNavigate();
 
-    // get all the matches of the player has participated in
+    // get all the valid matches the player has participated in
     const matches = filterMatchesByPlayerCount(useSelector((state: AppState) =>
         StatsSelectors.getMatchesByPlayerName(state, playerId, dateFilter)
     ), NUMBER_OF_PLAYERS_FOR_VALID_MATCH);

--- a/src/components/playerOverview/CommanderMatchupsTable.tsx
+++ b/src/components/playerOverview/CommanderMatchupsTable.tsx
@@ -10,6 +10,8 @@ import {
     commanderMatchupsColumns
 } from "../dataVisualizations/columnHelpers/commanderMatchupsColumnHelper";
 import { commanderList } from "../../services/commanderList";
+import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
+import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../constants";
 
 export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable({
     playerId,
@@ -21,9 +23,9 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
     const navigate = useNavigate();
 
     // get all the matches of the player has participated in
-    const matches = useSelector((state: AppState) =>
+    const matches = filterMatchesByPlayerCount(useSelector((state: AppState) =>
         StatsSelectors.getMatchesByPlayerName(state, playerId, dateFilter)
-    );
+    ), NUMBER_OF_PLAYERS_FOR_VALID_MATCH);
     const commanderMatchups: { [commanderId: string]: CommanderMatchupItem } = {};
 
     for (const match of matches) {

--- a/src/components/playerOverview/PlayerMatchupsTable.tsx
+++ b/src/components/playerOverview/PlayerMatchupsTable.tsx
@@ -9,6 +9,8 @@ import {
     PlayerMatchupItem,
     playerMatchupsColumns
 } from "../dataVisualizations/columnHelpers/playerMatchupsColumnHelper";
+import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
+import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../constants";
 
 export const PlayerMatchupsTable = React.memo(function PlayerMatchupsTable({
     playerId,
@@ -19,10 +21,10 @@ export const PlayerMatchupsTable = React.memo(function PlayerMatchupsTable({
 }) {
     const navigate = useNavigate();
 
-    // get all the matches of the player has participated in
-    const matches = useSelector((state: AppState) =>
+    // get all the valid matches the player has participated in
+    const matches = filterMatchesByPlayerCount(useSelector((state: AppState) =>
         StatsSelectors.getMatchesByPlayerName(state, playerId, dateFilter)
-    );
+    ), NUMBER_OF_PLAYERS_FOR_VALID_MATCH);
     const playerMatchups: { [playerId: string]: PlayerMatchupItem } = {};
 
     for (const match of matches) {

--- a/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
-
 import { Flex, Heading, Text } from "@chakra-ui/react";
-
 import { StatsSelectors } from "../../../redux/stats/statsSelectors";
 import { AppState } from "../../../redux/rootReducer";
 import { MTG_COLORS } from "../../constants";
@@ -98,7 +96,12 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
                     borderLeftWidth={1}
                     borderRightWidth={1}
                     borderBottomWidth={1}
-                >{`Winrate: ${getWinRatePercentage(player.wins, player.validMatchesCount)}%`}</Text>
+                >{`Winrate: ${
+                    player.validMatchesCount > 0
+                        ? `${getWinRatePercentage(player.wins, player.validMatchesCount)}%`
+                        : "N/A" // Displays N/A if the player has no valid matches
+                }`}
+                </Text>
                 <Text
                     paddingLeft={"16px"}
                     paddingRight={"16px"}

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -52,7 +52,7 @@ export function getAverageWinTurn(player: Player) {
     // Early exit conditions
     // Don't show if player has fewer than 10 matches or 5 wins all time
     if (player.validMatchesCount < PLAYER_MINIMUM_GAMES_REQUIRED) {
-        return "Not enough games played";
+        return "Not enough games";
     } else if (player.wins < PLAYER_MINIMUM_WINS_REQUIRED) {
         return "Not enough wins";
     }


### PR DESCRIPTION
Winrates and getWinRatePercentage updates left behind a few edge cases where a player had no valid matches or a commander had no valid matches mostly due to some old three player games being recorded in the data.

The displayed value was 0% but since we use 0 as the number of matches to the end user it would imply division by 0 which makes no sense. Hence replaced all instances of 0% with N/A across multiple instances in multiple files.

The player and commander matchup tables were using unfiltered matches. This resulted in cases where a player with no valid matches still had a matchup table. This was also addressed by both creating a condition for when a winrate is invalid and by filtering the data for valid matches.

This fix affects the player Alzaro and four commanders.