### PR TITLE
better readability and scalability in bar graphs with differing numbers of matches

### DIFF
--- a/src/components/commanderOverview/MatchPlacementBarChart.tsx
+++ b/src/components/commanderOverview/MatchPlacementBarChart.tsx
@@ -42,6 +42,8 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
     const matchPlacementData = Object.keys(matchPlacementDictionary).map((rank: string) => {
         return { x: Number(rank), y: matchPlacementDictionary[rank] };
     });
+    
+    const matchPlacementMaxY = Math.max(...matchPlacementData.map(height => height.y)); // Finds the tallest column
 
     const tooltipTitleCallback = (item: TooltipItem<"bar">[]) => {
         return `Games placed in rank ${matchPlacementData[item[0].dataIndex].x}: ${
@@ -60,7 +62,7 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
                 data={matchPlacementData}
                 tooltipTitleCallback={tooltipTitleCallback}
                 tooltipLabelCallback={tooltipLabelCallback}
-                maxY={validMatches.length}
+                maxY={matchPlacementMaxY + 5}
             />
         </Flex>
     );

--- a/src/components/matchTrends/MatchLengthBarChart.tsx
+++ b/src/components/matchTrends/MatchLengthBarChart.tsx
@@ -22,6 +22,8 @@ export const MatchLengthBarChart = React.memo(function MatchHistory({ matches }:
         return { x: Number(numberOfTurns), y: matchesLengthDictionary[numberOfTurns] };
     });
 
+    const matchLengthsMaxY = Math.max(...matchesWithLengthsData.map(height => height.y)); // Finds the tallest column
+
     const tooltipTitleCallback = (item: TooltipItem<"bar">[]) => {
         return `Games with ${matchesWithLengthsData[item[0].dataIndex].x} turns: ${
             matchesWithLengthsData[item[0].dataIndex].y
@@ -39,7 +41,7 @@ export const MatchLengthBarChart = React.memo(function MatchHistory({ matches }:
                 data={matchesWithLengthsData}
                 tooltipTitleCallback={tooltipTitleCallback}
                 tooltipLabelCallback={tooltipLabelCallback}
-                maxY={50}
+                maxY={matchLengthsMaxY + 5}
             />
         </>
     );

--- a/src/components/playerOverview/MatchPlacementBarChart.tsx
+++ b/src/components/playerOverview/MatchPlacementBarChart.tsx
@@ -43,6 +43,8 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
         return { x: Number(rank), y: matchPlacementDictionary[rank] };
     });
 
+    const matchPlacementMaxY = Math.max(...matchPlacementData.map(height => height.y)); // Finds the tallest column
+
     const tooltipTitleCallback = (item: TooltipItem<"bar">[]) => {
         return `Games placed in rank ${matchPlacementData[item[0].dataIndex].x}: ${
             matchPlacementData[item[0].dataIndex].y
@@ -61,7 +63,7 @@ export const MatchPlacementBarChart = React.memo(function MatchPlacementBarChart
                     data={matchPlacementData}
                     tooltipTitleCallback={tooltipTitleCallback}
                     tooltipLabelCallback={tooltipLabelCallback}
-                    maxY={validMatches.length}
+                    maxY={Math.max(matchPlacementMaxY + 5)}
                 />
             ) : (
                 <InsufficientData description={"Not enough matches"} />


### PR DESCRIPTION
Problem: some players have 20 matches, some have 200. The bar graph showing their placements (and the general one in Match Trends) had a fixed Y-maximum which made some graphs look very flat and somewhat unreadable.

Solution: this fix changes the maxY value of each bar graph to scale with the tallest column (and adds +5 to it) to make the graphs more readable.