### PR TITLE
Add support for auth expiration

### DIFF
--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -31,7 +31,7 @@ export const LoginModal = React.memo(function LoginModal({
 }) {
     const dispatch = useDispatch();
     const { isOpen, onOpen, onClose } = useDisclosure();
-    const { accessToken, tokenType } = useAuthInfo();
+    const { accessToken, tokenType, expirationDate } = useAuthInfo();
     const { userPic, username } = useUserInfo();
 
     const isFirstLogin = useSelector(AuthSelectors.getIsFirstLogin);
@@ -60,13 +60,16 @@ export const LoginModal = React.memo(function LoginModal({
             if (accessToken) {
                 localStorage.setItem("accessToken", accessToken);
             }
+            if (expirationDate) {
+                localStorage.setItem("expirationDate", expirationDate.getTime().toString());
+            }
         } else {
             localStorage.clear();
         }
 
         dispatch(AuthAction.FirstLoginComplete());
         onClose();
-    }, [accessToken, dispatch, isRememberMe, onClose, tokenType]);
+    }, [accessToken, dispatch, expirationDate, isRememberMe, onClose, tokenType]);
 
     const handleLoginModalCancel = useCallback(() => {
         onSignOut();

--- a/src/components/auth/SettingsModal.tsx
+++ b/src/components/auth/SettingsModal.tsx
@@ -38,7 +38,7 @@ export const SettingsMenuItem = React.memo(function SettingsMenuItem({ finalRef 
     const { isOpen, onOpen, onClose } = useDisclosure();
     const setFavoriteCommander = ProfileService.useSetFavoriteCommander();
     const getPlayerName = ProfileService.useGetPlayerName();
-    const { accessToken, tokenType } = useAuthInfo();
+    const { accessToken, tokenType, expirationDate } = useAuthInfo();
     const { userId, userPic, username } = useUserInfo();
 
     const accessTokenFromState = localStorage.getItem("tokenType");
@@ -93,10 +93,13 @@ export const SettingsMenuItem = React.memo(function SettingsMenuItem({ finalRef 
             if (accessToken) {
                 localStorage.setItem("accessToken", accessToken);
             }
+            if (expirationDate) {
+                localStorage.setItem("expirationDate", expirationDate.getTime().toString());
+            }
         }
 
         setIsRememberMe(!isRememberMe);
-    }, [accessToken, isRememberMe, tokenType]);
+    }, [accessToken, expirationDate, isRememberMe, tokenType]);
 
     // TODO: we should figure out a way that hiding the modal forces an unmount of this entire component instead of just tying it to the menu item.
     const openModal = useCallback(() => {

--- a/src/components/home/Login.tsx
+++ b/src/components/home/Login.tsx
@@ -30,7 +30,8 @@ export const Login = React.memo(function Login({ hash }: { hash: string }) {
     dispatch(
         AuthAction.GetAuthComplete({
             tokenType: fragmentParts["token_type"],
-            accessToken: fragmentParts["access_token"]
+            accessToken: fragmentParts["access_token"],
+            expirationTimeInSeconds: Number(fragmentParts["expires_in"])
         })
     );
 

--- a/src/logic/hooks/authHooks.ts
+++ b/src/logic/hooks/authHooks.ts
@@ -5,9 +5,11 @@ import { AuthSelectors } from "../../redux/auth/authSelectors";
 export const useAuthInfo = () => {
     const tokenType = useSelector(AuthSelectors.getTokenType);
     const accessToken = useSelector(AuthSelectors.getAccessToken);
+    const expirationDate = useSelector(AuthSelectors.getExpirationDate);
 
     return {
         tokenType,
-        accessToken
+        accessToken,
+        expirationDate
     };
 };

--- a/src/navigation/Root.tsx
+++ b/src/navigation/Root.tsx
@@ -8,12 +8,13 @@ import { ProfileService } from "../services/ProfileService";
 
 export default function Root() {
     const hydrateProfiles = ProfileService.useHydrateProfiles();
+    const getCurrentUserInfo = DiscordService.useGetCurrentUserInfo();
 
     // kick off the initial data hydration
     MatchHistoryService.useMatchHistory();
 
     // initiates the hydration of the discord info for the current user
-    DiscordService.useCurrentUserInfo();
+    getCurrentUserInfo();
 
     // make the initial call to hydrate profiles
     hydrateProfiles();

--- a/src/redux/auth/authActions.ts
+++ b/src/redux/auth/authActions.ts
@@ -13,14 +13,14 @@ export enum AuthActionType {
 export const AuthAction = {
     GetAuthComplete: createAction(
         AuthActionType.GetAuthComplete,
-        (data: { tokenType: string; accessToken: string }) => ({
+        (data: { tokenType: string; accessToken: string; expirationTimeInSeconds: number }) => ({
             type: AuthActionType.GetAuthComplete,
             payload: data
         })
     ),
     LoadAuthComplete: createAction(
         AuthActionType.LoadAuthComplete,
-        (data: { tokenType: string; accessToken: string }) => ({
+        (data: { tokenType: string; accessToken: string; expirationDate: Date }) => ({
             type: AuthActionType.LoadAuthComplete,
             payload: data
         })

--- a/src/redux/auth/authReducer.ts
+++ b/src/redux/auth/authReducer.ts
@@ -12,6 +12,7 @@ export type AuthState = Readonly<{
     // access_token
     accessToken: string | undefined;
     // expires_in
+    expirationDate: Date | undefined;
     // scope
     // state
 }>;
@@ -19,7 +20,8 @@ export type AuthState = Readonly<{
 const initialState: AuthState = {
     tokenType: undefined,
     accessToken: undefined,
-    isFirstLogin: false
+    isFirstLogin: false,
+    expirationDate: undefined
 };
 
 export const authReducer = createReducer(initialState, (builder) => {
@@ -27,11 +29,17 @@ export const authReducer = createReducer(initialState, (builder) => {
         .addCase(AuthAction.GetAuthComplete, (state, action) => {
             state.accessToken = action.payload.accessToken;
             state.tokenType = action.payload.tokenType;
+
+            // compute the expiration date
+            const expirationDate = new Date(new Date().getTime() + action.payload.expirationTimeInSeconds * 1000);
+            state.expirationDate = expirationDate;
+
             state.isFirstLogin = true;
         })
         .addCase(AuthAction.LoadAuthComplete, (state, action) => {
             state.accessToken = action.payload.accessToken;
             state.tokenType = action.payload.tokenType;
+            state.expirationDate = action.payload.expirationDate;
         })
         .addCase(AuthAction.LogOut, (state, _action) => {
             state.accessToken = undefined;

--- a/src/redux/auth/authSelectors.ts
+++ b/src/redux/auth/authSelectors.ts
@@ -3,9 +3,11 @@ import { AppState } from "../rootReducer";
 const getTokenType = (state: AppState) => state.auth.tokenType;
 const getAccessToken = (state: AppState) => state.auth.accessToken;
 const getIsFirstLogin = (state: AppState) => state.auth.isFirstLogin;
+const getExpirationDate = (state: AppState) => state.auth.expirationDate;
 
 export const AuthSelectors = {
     getTokenType,
     getAccessToken,
-    getIsFirstLogin
+    getIsFirstLogin,
+    getExpirationDate
 };

--- a/src/services/DiscordService.ts
+++ b/src/services/DiscordService.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { useDispatch, useSelector } from "react-redux";
 
-import { useEffect } from "react";
+import { useCallback } from "react";
 import { UserAction } from "../redux/user/userActions";
 import { UserSelectors } from "../redux/user/userSelectors";
 import { useAuthInfo } from "../logic/hooks/authHooks";
@@ -15,7 +15,7 @@ export const getDiscordAvatarImage = (userId: string, userAvatar: string) => {
     return `https://cdn.discordapp.com/avatars/${userId}/${userAvatar}.png`;
 };
 
-const useCurrentUserInfo = () => {
+const useGetCurrentUserInfo = () => {
     const dispatch = useDispatch();
     const { accessToken, tokenType } = useAuthInfo();
 
@@ -23,7 +23,7 @@ const useCurrentUserInfo = () => {
 
     const endpoint = "https://discord.com/api/users/@me";
 
-    useEffect(() => {
+    return useCallback(() => {
         // if the user is signed in but we don't have the discord information for that user, request that information
         if (accessToken !== undefined && isUserSignedIn === false) {
             axios
@@ -45,5 +45,5 @@ const useCurrentUserInfo = () => {
 };
 
 export const DiscordService = {
-    useCurrentUserInfo
+    useGetCurrentUserInfo
 };


### PR DESCRIPTION
Add support for auth expiration. When the auth token expires, we'll log the user out, forcing them to sign in. 

persisting this to the local storage so when the token is loaded, we know if it should be refreshed or not. 

Also change the existing useCurrentUserInfo to be a callback instead.