### PR TITLE
useTableFilters hook

### DIFF
--- a/src/components/commanderOverview/CommanderOverview.tsx
+++ b/src/components/commanderOverview/CommanderOverview.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { useSelector } from "react-redux";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
-import { Checkbox, Flex, Tooltip, Input } from "@chakra-ui/react";
+import { Checkbox, Flex, Input, Tooltip } from "@chakra-ui/react";
 
 import { SortableTable } from "../dataVisualizations/SortableTable";
 import { commanderOverviewColumns } from "../dataVisualizations/columnHelpers/commanderOverviewColumnHelper";
@@ -12,73 +12,24 @@ import { Commander } from "../../types/domain/Commander";
 import { COMMANDER_MINIMUM_GAMES_REQUIRED } from "../constants";
 import { AppState } from "../../redux/rootReducer";
 import { DatePicker } from "../common/DatePicker";
+import { useTableFilters } from "../../logic/hooks/tableHooks";
 
 export const CommanderOverview = React.memo(function MatchHistory() {
     const navigate = useNavigate();
 
-    const [searchParams, setSearchParams] = useSearchParams();
-    // try to get the date out of the search params
-    const dateFilterParamRaw = searchParams.get("fromDate");
-    const dateFilterParam = dateFilterParamRaw !== null ? new Date(Number(dateFilterParamRaw)) ?? undefined : undefined;
-    // try to get the qualified filter out of the search params
-    const onlyQualifiedParamRaw = searchParams.get("onlyQualified");
-    const onlyQualifiedParam = onlyQualifiedParamRaw !== null ? onlyQualifiedParamRaw === "true" : false;
-    // try to get the free form name filter out of the search params
-    const nameFilterParamRaw = searchParams.get("filter");
-    const nameFilterParam = nameFilterParamRaw !== null ? nameFilterParamRaw : "";
-
-    const [dateFilter, setDateFilter] = useState<Date | undefined>(dateFilterParam);
-    const onDatePickerChange = useCallback((date: Date | undefined) => {
-        setDateFilter(date);
-    }, []);
-
     const allCommanders = useSelector(StatsSelectors.getCommanders);
+    const { dateFilter, showOnlyQualfied, searchInput, onDatePickerChange, onShowOnlyQualifiedChange, onSearchChange } =
+        useTableFilters();
+
     const commanders: Commander[] = useSelector((state: AppState) =>
         StatsSelectors.getCommandersByDate(state, dateFilter)
     );
-    const [showOnlyQualfied, setShowOnlyQualified] = useState<boolean>(onlyQualifiedParam);
-    const onFilterChange = () => {
-        setShowOnlyQualified(!showOnlyQualfied);
-    };
-
-    const [searchInput, setSearchInput] = useState<string>(nameFilterParam);
-    const onSearchChange = useCallback(
-        (event: any) => {
-            setSearchInput(event.target.value);
-        },
-        [setSearchInput]
-    );
-
-    // this useEffect is listening to all of the filter changes and applying to them to the search parameters
-    useEffect(() => {
-        // date filter
-        if (dateFilter) {
-            searchParams.set("fromDate", dateFilter.getTime().toString());
-        } else {
-            searchParams.delete("fromDate");
-        }
-        // qualified filter
-        // since the field is true, toggling it off should remove the filter
-        if (showOnlyQualfied) {
-            searchParams.set("onlyQualified", "true");
-        } else {
-            searchParams.delete("onlyQualified");
-        }
-
-        if (searchInput) {
-            searchParams.set("filter", searchInput);
-        } else {
-            searchParams.delete("filter");
-        }
-
-        setSearchParams(searchParams);
-    }, [dateFilter, nameFilterParam, searchInput, searchParams, setSearchParams, showOnlyQualfied]);
-
     if (commanders === undefined || commanders.length === 0) {
         return <Loading text="Loading..." />;
     }
 
     let commandersArray = commanders.sort((a: Commander, b: Commander) => a.name.localeCompare(b.name));
+
     if (showOnlyQualfied && allCommanders) {
         commandersArray = commandersArray.filter(
             (value: Commander) => allCommanders[value.id].validMatchesCount >= COMMANDER_MINIMUM_GAMES_REQUIRED
@@ -109,7 +60,7 @@ export const CommanderOverview = React.memo(function MatchHistory() {
                     arrowSize={15}
                 >
                     <div style={{ marginTop: "8px", marginBottom: "8px" }}>
-                        <Checkbox isChecked={showOnlyQualfied} onChange={onFilterChange}>
+                        <Checkbox isChecked={showOnlyQualfied} onChange={onShowOnlyQualifiedChange}>
                             {"Show only qualified"}
                         </Checkbox>
                     </div>

--- a/src/components/dataVisualizations/SortableTable.tsx
+++ b/src/components/dataVisualizations/SortableTable.tsx
@@ -17,7 +17,7 @@ import { primaryColor } from "../../themes/acorn";
 
 const defaultPropGetter = () => ({});
 
-export function SortableTable({
+export const SortableTable = React.memo(function SortableTable({
     columns,
     data,
     defaultSort = [],
@@ -115,4 +115,4 @@ export function SortableTable({
             </Table>
         </TableContainer>
     );
-}
+});

--- a/src/components/playerOverview/PlayerOverview.tsx
+++ b/src/components/playerOverview/PlayerOverview.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Flex, Tooltip } from "@chakra-ui/react";
+import { Checkbox, Flex, Input, Tooltip } from "@chakra-ui/react";
 import React, { useCallback, useState } from "react";
 import { SortableTable } from "../dataVisualizations/SortableTable";
 import { playerOverviewColumns } from "../dataVisualizations/columnHelpers/playerOverviewColumnHelper";
@@ -10,6 +10,7 @@ import { useNavigate } from "react-router-dom";
 import { PLAYER_MINIMUM_GAMES_REQUIRED } from "../constants";
 import { AppState } from "../../redux/rootReducer";
 import { DatePicker } from "../common/DatePicker";
+import { useTableFilters } from "../../logic/hooks/tableHooks";
 
 /**
  * Component showing all the players in a big list
@@ -17,30 +18,26 @@ import { DatePicker } from "../common/DatePicker";
 export const PlayerOverview = React.memo(function MatchHistory() {
     const navigate = useNavigate();
 
-    const [dateFilter, setDateFilter] = useState<Date | undefined>(undefined);
-    const onDatePickerChange = useCallback(
-        (date: Date | undefined) => {
-            setDateFilter(date);
-        },
-        [setDateFilter]
-    );
+    const { dateFilter, showOnlyQualfied, searchInput, onDatePickerChange, onShowOnlyQualifiedChange, onSearchChange } =
+        useTableFilters();
 
     const allPlayers: { [id: string]: Player } | undefined = useSelector(StatsSelectors.getPlayers);
     const players: Player[] = useSelector((state: AppState) => StatsSelectors.getPlayersByDate(state, dateFilter));
-
-    const [isFiltered, setIsFiltered] = useState<boolean>(true);
-    const onFilterChange = () => {
-        setIsFiltered(!isFiltered);
-    };
 
     if (allPlayers === undefined) {
         return <Loading text="Loading..." />;
     }
 
     let playersArray = players.sort((a: Player, b: Player) => a.name.localeCompare(b.name));
-    if (isFiltered) {
+    if (showOnlyQualfied) {
         playersArray = playersArray.filter(
             (value: Player) => allPlayers[value.name].validMatchesCount >= PLAYER_MINIMUM_GAMES_REQUIRED
+        );
+    }
+
+    if (searchInput.length > 0 && allPlayers) {
+        playersArray = playersArray.filter((value: Player) =>
+            allPlayers[value.name].name.toLowerCase().includes(searchInput.toLowerCase())
         );
     }
 
@@ -54,11 +51,14 @@ export const PlayerOverview = React.memo(function MatchHistory() {
                     arrowSize={15}
                 >
                     <div>
-                        <Checkbox isChecked={isFiltered} onChange={onFilterChange}>
+                        <Checkbox isChecked={showOnlyQualfied} onChange={onShowOnlyQualifiedChange}>
                             {"Show only qualified"}
                         </Checkbox>
                     </div>
                 </Tooltip>
+                <div style={{ padding: 20 }}>
+                    <Input placeholder="Filter by..." onChange={onSearchChange} value={searchInput} />
+                </div>
             </Flex>
             <SortableTable
                 columns={playerOverviewColumns}

--- a/src/logic/hooks/tableHooks.ts
+++ b/src/logic/hooks/tableHooks.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * This hook returns a set of values and setters that handle updating table filter values populated from the url parameters.
+ * This also will update the history backstack so the filters are persisted.
+ */
+export const useTableFilters = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    // try to get the date out of the search params
+    const dateFilterParamRaw = searchParams.get("fromDate");
+    const dateFilterParam = dateFilterParamRaw !== null ? new Date(Number(dateFilterParamRaw)) ?? undefined : undefined;
+    // try to get the qualified filter out of the search params
+    const onlyQualifiedParamRaw = searchParams.get("onlyQualified");
+    // the default value for the qualified param is true
+    const onlyQualifiedParam = onlyQualifiedParamRaw !== null ? onlyQualifiedParamRaw === "true" : true;
+    // try to get the free form name filter out of the search params
+    const nameFilterParamRaw = searchParams.get("filter");
+    const nameFilterParam = nameFilterParamRaw !== null ? nameFilterParamRaw : "";
+
+    const [dateFilter, setDateFilter] = useState<Date | undefined>(dateFilterParam);
+    const onDatePickerChange = useCallback((date: Date | undefined) => {
+        setDateFilter(date);
+    }, []);
+
+    const [showOnlyQualfied, setShowOnlyQualified] = useState<boolean>(onlyQualifiedParam);
+    const onShowOnlyQualifiedChange = () => {
+        setShowOnlyQualified(!showOnlyQualfied);
+    };
+
+    const [searchInput, setSearchInput] = useState<string>(nameFilterParam);
+    const onSearchChange = useCallback(
+        (event: any) => {
+            setSearchInput(event.target.value);
+        },
+        [setSearchInput]
+    );
+
+    // this useEffect is listening to all of the filter changes and applying to them to the search parameters
+    useEffect(() => {
+        // date filter
+        if (dateFilter) {
+            searchParams.set("fromDate", dateFilter.getTime().toString());
+        } else {
+            searchParams.delete("fromDate");
+        }
+
+        // qualified filter
+        // this will make sure that the qualified filter is always set in the url
+        searchParams.set("onlyQualified", showOnlyQualfied.toString());
+
+        if (searchInput) {
+            searchParams.set("filter", searchInput);
+        } else {
+            searchParams.delete("filter");
+        }
+
+        setSearchParams(searchParams);
+    }, [dateFilter, nameFilterParam, searchInput, searchParams, setSearchParams, showOnlyQualfied]);
+
+    return {
+        dateFilter,
+        showOnlyQualfied,
+        searchInput,
+        onDatePickerChange,
+        onShowOnlyQualifiedChange,
+        onSearchChange
+    };
+};


### PR DESCRIPTION
This new hook creates a common set of logic of handling how the values of a table filter are read off of URL parameters as well as set the URL parameters if they are toggled on the page.

This only creates the values and the onChange handlers, and they still have to be actually hooked up to the components on the page (and also apply the appropriate filters based on the filter values). 