### PR TITLE
Notice of unsaved profile changes

### DIFF
--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -106,6 +106,12 @@ export const SettingsMenuItem = React.memo(function SettingsMenuItem({ finalRef 
                         </Flex>
                         <PersistSignInSection />
                     </ModalBody>
+                    {profile &&
+                        (profile.favoriteCommanderId !== commanderSelectValue || profile.moxfieldId !== moxfieldId) && (
+                            <Flex justifyContent={"center"} color={"red"} paddingBottom={"8px"}>
+                                You have unsaved profile changes!
+                            </Flex>
+                        )}
                     <ModalFooter>
                         <Button mr={3} onClick={onSave} isDisabled={hasErrors}>
                             Save
@@ -114,12 +120,6 @@ export const SettingsMenuItem = React.memo(function SettingsMenuItem({ finalRef 
                             Close
                         </Button>
                     </ModalFooter>
-                    {profile &&
-                        (profile.favoriteCommanderId !== commanderSelectValue || profile.moxfieldId !== moxfieldId) && (
-                            <Flex justifyContent={"center"} color={"red"} paddingBottom={"8px"}>
-                                You have unsaved profile changes!
-                            </Flex>
-                        )}
                 </ModalContent>
             </Modal>
         </>

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -114,6 +114,12 @@ export const SettingsMenuItem = React.memo(function SettingsMenuItem({ finalRef 
                             Close
                         </Button>
                     </ModalFooter>
+                    {profile &&
+                        (profile.favoriteCommanderId !== commanderSelectValue || profile.moxfieldId !== moxfieldId) && (
+                            <Flex justifyContent={"center"} color={"red"} paddingBottom={"8px"}>
+                                You have unsaved profile changes!
+                            </Flex>
+                        )}
                 </ModalContent>
             </Modal>
         </>


### PR DESCRIPTION
In order to display the test, check if a profile is loaded, and if any of the state variables that are tracking input don't match the value in the profile