### PR TITLE
Move Toski to Discord mapping to chatterfang

### DIFF
--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo } from "react";
 import { FiMenu, FiChevronDown } from "react-icons/fi";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import {
@@ -25,9 +25,10 @@ import { routes } from "../../navigation/routes";
 import { FF_IS_LOGIN_ENABLED } from "../../services/featureFlagService";
 import { LoginModal } from "../auth/LoginModal";
 import { SettingsMenuItem } from "../settings/SettingsModal";
-import { ProfileService } from "../../services/ProfileService";
 import { getDiscordLoginEndpoint } from "../../services/DiscordService";
 import { useUserInfo } from "../../logic/hooks/userHooks";
+import { AppState } from "../../redux/rootReducer";
+import { ProfileSelectors } from "../../redux/profiles/profilesSelectors";
 
 const placeholderImage = "https://static.thenounproject.com/png/5425-200.png";
 
@@ -70,7 +71,6 @@ export const useHeaderTitle = () => {
 export const Header = ({ onProfileIconClick, ...rest }: HeaderProps) => {
     const dispatch = useDispatch();
     const navigate = useNavigate();
-    const getPlayerName = ProfileService.useGetPlayerName();
 
     const headerTitle = useHeaderTitle();
     const location = useLocation();
@@ -79,6 +79,8 @@ export const Header = ({ onProfileIconClick, ...rest }: HeaderProps) => {
     const finalRef = React.useRef(null);
 
     const { userId, userPic, username } = useUserInfo();
+
+    const profile = useSelector((state: AppState) => ProfileSelectors.getProfile(state, userId ?? ""));
 
     /**
      * When the app starts, we check to see if there's an existing access token already saved via local storage.
@@ -120,12 +122,11 @@ export const Header = ({ onProfileIconClick, ...rest }: HeaderProps) => {
 
     const navigateToProfile = useCallback(() => {
         // find the player name based on their discord id
-        const playerName = getPlayerName(userId ?? "");
-        if (playerName) {
-            navigate(`/playerOverview/${playerName}`);
+        if (profile?.toskiId) {
+            navigate(`/playerOverview/${profile?.toskiId}`);
             window.scrollTo(0, 0);
         }
-    }, [getPlayerName, navigate, userId]);
+    }, [navigate, profile?.toskiId]);
 
     return (
         <Flex

--- a/src/components/playerOverview/playerDetails/PlayerDetails.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetails.tsx
@@ -30,7 +30,6 @@ import { InsufficientData } from "../InsufficientData";
 import { CommanderMatchupsTable } from "../CommanderMatchupsTable";
 import { PlayerMatchupsTable } from "../PlayerMatchupsTable";
 import { primaryColor } from "../../../themes/acorn";
-import { ProfileService } from "../../../services/ProfileService";
 import { ProfileSelectors } from "../../../redux/profiles/profilesSelectors";
 import { PlayerDecks } from "./PlayerDecks";
 
@@ -42,12 +41,11 @@ export const PlayerDetails = React.memo(function PlayerDetails() {
     const navigate = useNavigate();
     // Player variables
     const playerId = useLoaderData() as string;
-    const getProfileId = ProfileService.useGetProfileId();
 
     const player = useSelector((state: AppState) => StatsSelectors.getPlayer(state, playerId));
-    const potentialProfileId = player ? getProfileId(player.name) : undefined;
-    const profileId = potentialProfileId ?? "";
-    const profile = useSelector((state: AppState) => ProfileSelectors.getProfile(state, profileId));
+    const toskiToDiscordMap = useSelector((state: AppState) => state.profiles.toskiToDiscordMap);
+    const profileId = toskiToDiscordMap && player ? toskiToDiscordMap[player.name.toLowerCase()] : undefined;
+    const profile = useSelector((state: AppState) => ProfileSelectors.getProfile(state, profileId ?? ""));
     const commanders = useSelector((state: AppState) => StatsSelectors.getCommanders(state));
 
     const [showCommanderMatchups, setShowCommanderMatchups] = useState<boolean>(false);
@@ -199,7 +197,7 @@ export const PlayerDetails = React.memo(function PlayerDetails() {
                             alignItems={"stretch"}
                             flexDirection={"row"}
                         >
-                            <PlayerDecks profileId={profileId} />
+                            <PlayerDecks profileId={profile ? profile.id : ""} />
                         </Flex>
                     </TabPanel>
                 </TabPanels>

--- a/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
@@ -25,9 +25,9 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
         StatsSelectors.getFavoriteCommanderForPlayer(state, playerId)
     );
 
-    const getProfileId = ProfileService.useGetProfileId();
-    const potentialProfileId = player ? getProfileId(player.name) : undefined;
-    const profileId = potentialProfileId ?? "";
+    const toskiToDiscordMap = useSelector((state: AppState) => state.profiles.toskiToDiscordMap);
+
+    const profileId = player && toskiToDiscordMap ? toskiToDiscordMap[player.name.toLowerCase()] : "";
     const profile = useSelector((state: AppState) => ProfileSelectors.getProfile(state, profileId));
 
     // TODO: let's move this to a selector

--- a/src/components/settings/DiscordAccountLinkingSection.tsx
+++ b/src/components/settings/DiscordAccountLinkingSection.tsx
@@ -8,15 +8,11 @@ import { CheckIcon, WarningTwoIcon } from "@chakra-ui/icons";
 import { useUserInfo } from "../../logic/hooks/userHooks";
 import { ProfileSelectors } from "../../redux/profiles/profilesSelectors";
 import { AppState } from "../../redux/rootReducer";
-import { ProfileService } from "../../services/ProfileService";
 
 export const DiscordAccountLinkingSection = React.memo(function DiscordAccountLinkingSection() {
-    const getPlayerName = ProfileService.useGetPlayerName();
-
     const { userId, userPic, username } = useUserInfo();
     const profile = useSelector((state: AppState) => ProfileSelectors.getProfile(state, userId ?? ""));
-
-    const toskiPlayer = getPlayerName(profile ? profile.id : "");
+    const toskiPlayer = profile?.toskiId;
 
     return (
         <Flex

--- a/src/redux/profiles/profilesReducer.ts
+++ b/src/redux/profiles/profilesReducer.ts
@@ -10,7 +10,7 @@ import { MoxfieldDeck } from "../../types/domain/MoxfieldDeck";
  */
 export type ProfilesState = Readonly<{
     /**
-     * A map of all profiles where the ID is the discord id.
+     * A map of all profiles where the key is the discord id and the value is the chatterfang profile.
      */
     profiles: { [id: string]: Profile } | undefined;
     /**
@@ -21,22 +21,32 @@ export type ProfilesState = Readonly<{
      * A map of Moxfield decks where the ID is the Moxfield deck id
      */
     moxfieldDecks: { [id: string]: MoxfieldDeck } | undefined;
+    /**
+     * A map of all linked toski accounts where the key is the all lower-case toski id and the value is the discord id
+     */
+    toskiToDiscordMap: { [id: string]: string } | undefined;
 }>;
 
 const initialState: ProfilesState = {
     profiles: undefined,
     moxfieldProfiles: undefined,
-    moxfieldDecks: undefined
+    moxfieldDecks: undefined,
+    toskiToDiscordMap: undefined
 };
 
 export const profilesReducer = createReducer(initialState, (builder) => {
     builder
         .addCase(ProfilesAction.GetProfilesComplete, (state, action) => {
-            const result: { [id: string]: Profile } = {};
+            const profilesMap: { [id: string]: Profile } = {};
+            const toskiToDiscordMap: { [id: string]: string } = {};
             for (const item of action.payload) {
-                result[item.id] = item;
+                profilesMap[item.id] = item;
+                if (item.toskiId) {
+                    toskiToDiscordMap[item.toskiId.toLowerCase()] = item.id;
+                }
             }
-            state.profiles = result;
+            state.profiles = profilesMap;
+            state.toskiToDiscordMap = toskiToDiscordMap;
         })
         .addCase(ProfilesAction.HydrateMoxfieldProfileComplete, (state, action) => {
             if (state.moxfieldProfiles === undefined) {

--- a/src/services/ProfileService.ts
+++ b/src/services/ProfileService.ts
@@ -10,16 +10,6 @@ import { profilesDataMapper } from "../types/service/ProfileService/dataMappers"
 import { ProfilesAction } from "../redux/profiles/profilesActions";
 import { MoxfieldService } from "./MoxfieldService";
 
-const profileMap: { [name: string]: string } = {
-    Doomgeek: "230904033915830272",
-    "Aetherium Slinky": "226715073031176193",
-    LumenAdi: "224315766042787840",
-    Wisecompany: "396390132988641281",
-    Leon_Von_Kaktuus: "563015313935826984",
-    Wrinklebuns: "187707404761169920",
-    WitchPHD: "71482669514366976"
-};
-
 const useHydrateProfiles = () => {
     const dispatch = useDispatch();
 
@@ -144,31 +134,9 @@ const useRemoveDeckFromProfile = () => {
     );
 };
 
-/**
- * Given a player name (not discord screen name), return the discord id
- */
-const useGetProfileId = (): ((playerName: string) => string | undefined) => {
-    return useCallback((playerName: string) => {
-        return profileMap[playerName] ?? "";
-    }, []);
-};
-
-/**
- * Given a discord id, return the player name (not discord screen name)
- * @param profileId The discord Id to search from
- * @returns The player name (not the discord screen name). Returns undefined if the mapping doesn't exist.
- */
-const useGetPlayerName = (): ((profileId: string) => string | undefined) => {
-    return useCallback((profileId: string) => {
-        return Object.keys(profileMap).find((name) => profileMap[name] === profileId);
-    }, []);
-};
-
 export const ProfileService = {
     useHydrateProfiles,
     useUpdateProfile,
-    useGetProfileId,
-    useGetPlayerName,
     useAddDeckToProfile,
     useRemoveDeckFromProfile
 };

--- a/src/types/domain/Profile.ts
+++ b/src/types/domain/Profile.ts
@@ -30,4 +30,6 @@ export type Profile = {
          */
         moxfieldId: string;
     }[];
+
+    toskiId?: string;
 };

--- a/src/types/service/ProfileService/ChatterfangProfile.ts
+++ b/src/types/service/ProfileService/ChatterfangProfile.ts
@@ -10,4 +10,5 @@ export type ChatterfangProfile = {
         deckId: string;
         source: string;
     }[];
+    toskiId?: string;
 };

--- a/src/types/service/ProfileService/dataMappers.ts
+++ b/src/types/service/ProfileService/dataMappers.ts
@@ -12,7 +12,8 @@ function profileDataMapper(profile: ChatterfangProfile): Profile | undefined {
                 ? profile.decks.map((deck) => {
                       return { id: deck._id, moxfieldId: deck.deckId };
                   })
-                : []
+                : [],
+            toskiId: profile.toskiId
         };
     }
 


### PR DESCRIPTION
This does an important cleanup step of moving toski to discord mappings entirely to the DB. 

This involves updating our service/domain types (toskId is now stored as part of the chatterfang profile) and then creating a new "toskiId to discord" map in the app state that is used to look up the chatterfang profile (since we use discord id for the chatterfang profile). 