### PR TITLE
Add archidedkt support for deck links

### DIFF
--- a/src/redux/profiles/profilesActions.ts
+++ b/src/redux/profiles/profilesActions.ts
@@ -2,11 +2,13 @@ import { createAction } from "@reduxjs/toolkit";
 import { Profile } from "../../types/domain/Profile";
 import { MoxfieldDeck } from "../../types/domain/MoxfieldDeck";
 import { MoxfieldProfile } from "../../types/domain/MoxfieldProfile";
+import { ArchidektDeck } from "../../types/domain/ArchidektDeck";
 
 export enum ProfilesActionType {
     GetProfilesComplete = "ProfileActions/GetProfilesComplete",
     HydrateMoxfieldProfileComplete = "ProfileActions/HydrateMoxfieldProfileComplete",
-    HydrateMoxfieldDeckComplete = "ProfileActions/HydrateMoxfieldDeckComplete"
+    HydrateMoxfieldDeckComplete = "ProfileActions/HydrateMoxfieldDeckComplete",
+    HydrateArchidektDeckComplete = "ProfileActions/HydrateArchidektDeckComplete"
 }
 
 export const ProfilesAction = {
@@ -24,5 +26,12 @@ export const ProfilesAction = {
     HydrateMoxfieldDeckComplete: createAction(ProfilesActionType.HydrateMoxfieldDeckComplete, (data: MoxfieldDeck) => ({
         type: ProfilesActionType.HydrateMoxfieldDeckComplete,
         payload: data
-    }))
+    })),
+    HydrateArchidektDeckComplete: createAction(
+        ProfilesActionType.HydrateArchidektDeckComplete,
+        (data: ArchidektDeck) => ({
+            type: ProfilesActionType.HydrateMoxfieldDeckComplete,
+            payload: data
+        })
+    )
 };

--- a/src/redux/profiles/profilesReducer.ts
+++ b/src/redux/profiles/profilesReducer.ts
@@ -4,6 +4,7 @@ import { ProfilesAction } from "./profilesActions";
 import { Profile } from "../../types/domain/Profile";
 import { MoxfieldProfile } from "../../types/domain/MoxfieldProfile";
 import { MoxfieldDeck } from "../../types/domain/MoxfieldDeck";
+import { ArchidektDeck } from "../../types/domain/ArchidektDeck";
 
 /**
  * State containing all game history data
@@ -22,6 +23,10 @@ export type ProfilesState = Readonly<{
      */
     moxfieldDecks: { [id: string]: MoxfieldDeck } | undefined;
     /**
+     * A map of Archidekt decks where the ID is the Archidekt deck id
+     */
+    archidektDecks: { [id: string]: ArchidektDeck } | undefined;
+    /**
      * A map of all linked toski accounts where the key is the all lower-case toski id and the value is the discord id
      */
     toskiToDiscordMap: { [id: string]: string } | undefined;
@@ -31,6 +36,7 @@ const initialState: ProfilesState = {
     profiles: undefined,
     moxfieldProfiles: undefined,
     moxfieldDecks: undefined,
+    archidektDecks: undefined,
     toskiToDiscordMap: undefined
 };
 
@@ -64,6 +70,15 @@ export const profilesReducer = createReducer(initialState, (builder) => {
                 state.moxfieldDecks = result;
             } else {
                 state.moxfieldDecks[action.payload.id] = action.payload;
+            }
+        })
+        .addCase(ProfilesAction.HydrateArchidektDeckComplete, (state, action) => {
+            if (state.archidektDecks === undefined) {
+                const result: { [id: string]: ArchidektDeck } = {};
+                result[action.payload.id] = action.payload;
+                state.archidektDecks = result;
+            } else {
+                state.archidektDecks[action.payload.id] = action.payload;
             }
         });
 });

--- a/src/redux/profiles/profilesSelectors.ts
+++ b/src/redux/profiles/profilesSelectors.ts
@@ -11,6 +11,8 @@ const getMoxfieldProfiles = (state: AppState) => state.profiles.moxfieldProfiles
 
 const getMoxfieldDecks = (state: AppState) => state.profiles.moxfieldDecks;
 
+const getArchidektDecks = (state: AppState) => state.profiles.archidektDecks;
+
 /**
  * Gets a specific profile based on discord id.
  */
@@ -45,6 +47,7 @@ export const ProfileSelectors = {
     getProfiles,
     getMoxfieldProfiles,
     getMoxfieldDecks,
+    getArchidektDecks,
     getProfile,
     getMoxfieldProfile,
     getMoxfieldDeck

--- a/src/services/ArchidektService.ts
+++ b/src/services/ArchidektService.ts
@@ -1,0 +1,70 @@
+import axios from "axios";
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+import { ProfilesAction } from "../redux/profiles/profilesActions";
+import { MoxfieldDeck } from "../types/domain/MoxfieldDeck";
+import { MoxfieldProfile } from "../types/domain/MoxfieldProfile";
+import { MoxfieldDeckResponseData } from "../types/service/MoxfieldService/MoxfieldDeckResponse";
+import { MoxfieldProfileResponseData } from "../types/service/MoxfieldService/MoxfieldProfileResponse";
+import { ArchidektDeckResponse } from "../types/service/ArchidektService/ArchidektDeckResponse";
+import { ArchidektDeck } from "../types/domain/ArchidektDeck";
+
+// const useHydrateArchidektProfile = () => {
+//     const dispatch = useDispatch();
+//     const endpoint = "https://chatterfang.onrender.com/archidekt/profile/";
+
+//     return useCallback(
+//         async (moxfieldId: string) => {
+//             try {
+//                 const _res = await axios.get<MoxfieldProfileResponseData>(endpoint + moxfieldId, {
+//                     headers: { "Content-Type": "application/json" }
+//                 });
+//                 const serviceObj: MoxfieldProfileResponseData = _res.data;
+//                 let newMoxfieldProfile: MoxfieldProfile = {
+//                     userName: serviceObj.userName,
+//                     imageUrl: serviceObj.profileImageUrl ? serviceObj.profileImageUrl : undefined
+//                 };
+//                 dispatch(ProfilesAction.HydrateMoxfieldProfileComplete(newMoxfieldProfile));
+//             } catch (err) {
+//                 console.error("Error in Hydrate Moxfield Profile" + err);
+//             }
+//         },
+//         [dispatch]
+//     );
+// };
+
+const useHydrateArchidektDeck = () => {
+    const dispatch = useDispatch();
+
+    const endpoint = "https://chatterfang.onrender.com/archidekt/deck/";
+
+    return useCallback(
+        async (archidektId: string) => {
+            try {
+                const _res = await axios.get<ArchidektDeckResponse>(endpoint + archidektId, {
+                    headers: { "Content-Type": "application/json" }
+                });
+                const serviceObj: ArchidektDeckResponse = _res.data;
+
+                // the only acceptable format is commander. Format 3 is commander.
+                if (serviceObj.deckFormat === 3) {
+                    const newArchidektDeck: ArchidektDeck = {
+                        id: serviceObj.id,
+                        name: serviceObj.name,
+                        url: "https://www.archidekt.com/decks/" + serviceObj.id,
+                        commanderImageUri: serviceObj.featured
+                    };
+                    dispatch(ProfilesAction.HydrateArchidektDeckComplete(newArchidektDeck));
+                }
+            } catch (err) {
+                console.error("Error in Hydrate Moxfield Deck" + err);
+            }
+        },
+        [dispatch]
+    );
+};
+
+export const ArchidektService = {
+    useHydrateArchidektDeck
+};

--- a/src/types/domain/ArchidektDeck.ts
+++ b/src/types/domain/ArchidektDeck.ts
@@ -1,5 +1,5 @@
 import { ExternalDeck } from "./ExternalDeck";
 
-export type MoxfieldDeck = {
-    commanderName: string;
+export type ArchidektDeck = {
+    commanderImageUri: string;
 } & ExternalDeck;

--- a/src/types/domain/DeckSource.ts
+++ b/src/types/domain/DeckSource.ts
@@ -1,0 +1,5 @@
+export enum DeckSource {
+    Unknown,
+    Moxfield,
+    Archidekt
+}

--- a/src/types/domain/ExternalDeck.ts
+++ b/src/types/domain/ExternalDeck.ts
@@ -1,0 +1,5 @@
+export type ExternalDeck = {
+    id: string;
+    name: string;
+    url: string;
+};

--- a/src/types/domain/Profile.ts
+++ b/src/types/domain/Profile.ts
@@ -1,3 +1,5 @@
+import { DeckSource } from "./DeckSource";
+
 /**
  * Represents metadata about a user of the site
  */
@@ -25,10 +27,21 @@ export type Profile = {
          * The id used to identify the deck in chatterfang.
          */
         id: string;
+
         /**
-         * The moxfield id of the deck that can be used in moxfield to look up information about the deck.
+         * An object with the information needed to find a deck from a deck provider
          */
-        moxfieldId: string;
+        externalId: {
+            /**
+             * The external id of this deck.
+             */
+            id: string;
+
+            /**
+             * The external source of this deck.
+             */
+            source: DeckSource;
+        };
     }[];
 
     /**

--- a/src/types/service/ArchidektService/ArchidektDeckResponse.ts
+++ b/src/types/service/ArchidektService/ArchidektDeckResponse.ts
@@ -1,0 +1,6 @@
+export type ArchidektDeckResponse = {
+    id: string; // This is the id of the deck (format ######)
+    name: string; // This is the friendly name of the deck
+    deckFormat: number; // Format "3" is commander
+    featured: string; // This is the image uri of the deck
+};

--- a/src/types/service/ProfileService/dataMappers.ts
+++ b/src/types/service/ProfileService/dataMappers.ts
@@ -1,5 +1,17 @@
+import { DeckSource } from "../../domain/DeckSource";
 import { Profile } from "../../domain/Profile";
 import { ChatterfangProfile } from "./ChatterfangProfile";
+
+function mapDeckSource(source: string): DeckSource {
+    switch (source) {
+        case "moxfield":
+            return DeckSource.Moxfield;
+        case "archidekt":
+            return DeckSource.Archidekt;
+        default:
+            return DeckSource.Unknown;
+    }
+}
 
 function profileDataMapper(profile: ChatterfangProfile): Profile | undefined {
     // check to see if the chatterfang profile has all the fields defined
@@ -10,7 +22,13 @@ function profileDataMapper(profile: ChatterfangProfile): Profile | undefined {
             moxfieldId: profile.moxfieldId ? profile.moxfieldId : undefined,
             decks: profile.decks
                 ? profile.decks.map((deck) => {
-                      return { id: deck._id, moxfieldId: deck.deckId };
+                      return {
+                          id: deck._id,
+                          externalId: {
+                              id: deck.deckId,
+                              source: mapDeckSource(deck.source)
+                          }
+                      };
                   })
                 : [],
             toskiId: profile.toskiId,


### PR DESCRIPTION
This change adds archidekt support. This entails hooking up an entirely new service as well as updating the state to have a cache of archidekt decks.

It also involved revising the structure of linked decks to allow for multiple sources (a lot of assumptions were made regarding moxfield being the only source). 