### PR TITLE
Move "data start date" picker to be a redux connected component

### DIFF
--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -79,19 +79,19 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
 
     // Get all matches to display in Match History of the Commander Overview
     const matches = useSelector((state: AppState) =>
-        StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)
+        StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "")
     );
 
     // Get matches filtered by player count to use in statistical calculations
     // These matches are considered "valid" because they all have the same number of players
     const validMatches = filterMatchesByPlayerCount(
         useSelector((state: AppState) =>
-            StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "", dateFilter)
+            StatsSelectors.getMatchesByCommanderName(state, commander ? commander.name : "")
         ),
         NUMBER_OF_PLAYERS_FOR_VALID_MATCH
     );
     const commanderPlayers: Player[] = useSelector((state: AppState) =>
-        StatsSelectors.getPlayersByCommanderName(state, commander ? commander.name : "", dateFilter)
+        StatsSelectors.getPlayersByCommanderName(state, commander ? commander.name : "")
     );
     commanderPlayers.sort((a: Player, b: Player) => b.validMatchesCount - a.validMatchesCount);
 
@@ -253,7 +253,7 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                 </Flex>
             </Flex>
             <Flex direction={"column"}>
-                <DatePicker onChange={onDatePickerChange} />
+                <DatePicker />
                 <div style={{ padding: 20 }}>
                     <Input placeholder="Filter by..." onChange={onSearchChange} />
                 </div>

--- a/src/components/commanderOverview/CommanderMatchupsTable.tsx
+++ b/src/components/commanderOverview/CommanderMatchupsTable.tsx
@@ -24,7 +24,7 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
 
     // get all the valid matches the commander has participated in
     const matches = filterMatchesByPlayerCount(
-        useSelector((state: AppState) => StatsSelectors.getMatchesByCommanderName(state, commanderName, dateFilter)),
+        useSelector((state: AppState) => StatsSelectors.getMatchesByCommanderName(state, commanderName)),
         NUMBER_OF_PLAYERS_FOR_VALID_MATCH
     );
     const commanderMatchups: { [commanderId: string]: CommanderMatchupItem } = {};

--- a/src/components/commanderOverview/CommanderOverview.tsx
+++ b/src/components/commanderOverview/CommanderOverview.tsx
@@ -21,9 +21,7 @@ export const CommanderOverview = React.memo(function MatchHistory() {
     const { dateFilter, showOnlyQualfied, searchInput, onDatePickerChange, onShowOnlyQualifiedChange, onSearchChange } =
         useTableFilters();
 
-    const commanders: Commander[] = useSelector((state: AppState) =>
-        StatsSelectors.getCommandersByDate(state, dateFilter)
-    );
+    const commanders: Commander[] = useSelector((state: AppState) => StatsSelectors.getCommandersByDate(state));
     if (commanders === undefined || commanders.length === 0) {
         return <Loading text="Loading..." />;
     }
@@ -50,7 +48,7 @@ export const CommanderOverview = React.memo(function MatchHistory() {
                 flexWrap={"wrap"}
                 justifyContent={"center"}
             >
-                <DatePicker onChange={onDatePickerChange} value={dateFilter} />
+                <DatePicker />
                 <Tooltip
                     label={<p style={{ textAlign: "center" }}>Commanders play 5 games to be qualified.</p>}
                     hasArrow

--- a/src/components/commanderOverview/PlayerMatchupsTable.tsx
+++ b/src/components/commanderOverview/PlayerMatchupsTable.tsx
@@ -23,7 +23,7 @@ export const PlayerMatchupsTable = React.memo(function PlayerMatchupsTable({
 
     // get all the valid matches the commander has participated in
     const matches = filterMatchesByPlayerCount(
-        useSelector((state: AppState) => StatsSelectors.getMatchesByCommanderName(state, commanderName, dateFilter)),
+        useSelector((state: AppState) => StatsSelectors.getMatchesByCommanderName(state, commanderName)),
         NUMBER_OF_PLAYERS_FOR_VALID_MATCH
     );
     const playerMatchups: { [playerId: string]: PlayerMatchupItem } = {};

--- a/src/components/playerOverview/CommanderHistoryTable.tsx
+++ b/src/components/playerOverview/CommanderHistoryTable.tsx
@@ -19,7 +19,7 @@ export const CommanderHistoryTable = React.memo(function CommanderHistoryTable({
 
     // Get array of commanders played and sort by game count
     const playedCommanders: Commander[] = useSelector((state: AppState) =>
-        StatsSelectors.getCommandersByPlayerName(state, playerId ? playerId : "", dateFilter)
+        StatsSelectors.getCommandersByPlayerName(state, playerId ? playerId : "")
     );
     playedCommanders.sort((a: Commander, b: Commander) => b.validMatchesCount - a.validMatchesCount);
 

--- a/src/components/playerOverview/CommanderMatchupsTable.tsx
+++ b/src/components/playerOverview/CommanderMatchupsTable.tsx
@@ -24,7 +24,7 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
 
     // get all the valid matches the player has participated in
     const matches = filterMatchesByPlayerCount(
-        useSelector((state: AppState) => StatsSelectors.getMatchesByPlayerName(state, playerId, dateFilter)),
+        useSelector((state: AppState) => StatsSelectors.getMatchesByPlayerName(state, playerId)),
         NUMBER_OF_PLAYERS_FOR_VALID_MATCH
     );
     const commanderMatchups: { [commanderId: string]: CommanderMatchupItem } = {};

--- a/src/components/playerOverview/PlayerMatchupsTable.tsx
+++ b/src/components/playerOverview/PlayerMatchupsTable.tsx
@@ -23,7 +23,7 @@ export const PlayerMatchupsTable = React.memo(function PlayerMatchupsTable({
 
     // get all the valid matches the player has participated in
     const matches = filterMatchesByPlayerCount(
-        useSelector((state: AppState) => StatsSelectors.getMatchesByPlayerName(state, playerId, dateFilter)),
+        useSelector((state: AppState) => StatsSelectors.getMatchesByPlayerName(state, playerId)),
         NUMBER_OF_PLAYERS_FOR_VALID_MATCH
     );
     const playerMatchups: { [playerId: string]: PlayerMatchupItem } = {};

--- a/src/components/playerOverview/PlayerOverview.tsx
+++ b/src/components/playerOverview/PlayerOverview.tsx
@@ -22,7 +22,7 @@ export const PlayerOverview = React.memo(function MatchHistory() {
         useTableFilters();
 
     const allPlayers: { [id: string]: Player } | undefined = useSelector(StatsSelectors.getPlayers);
-    const players: Player[] = useSelector((state: AppState) => StatsSelectors.getPlayersByDate(state, dateFilter));
+    const players: Player[] = useSelector((state: AppState) => StatsSelectors.getPlayersByDate(state));
 
     if (allPlayers === undefined) {
         return <Loading text="Loading..." />;
@@ -50,7 +50,7 @@ export const PlayerOverview = React.memo(function MatchHistory() {
                 flexWrap={"wrap"}
                 justifyContent={"center"}
             >
-                <DatePicker onChange={onDatePickerChange} value={dateFilter} />
+                <DatePicker />
                 <Tooltip
                     label={<p style={{ textAlign: "center" }}>Players play 10 games to be qualified.</p>}
                     hasArrow

--- a/src/components/playerOverview/playerDetails/PlayerDetails.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetails.tsx
@@ -69,7 +69,7 @@ export const PlayerDetails = React.memo(function PlayerDetails() {
 
     // needs to come after we initialize the date filter
     const matches = useSelector((state: AppState) =>
-        StatsSelectors.getMatchesByPlayerName(state, playerId ? playerId : "", dateFilter)
+        StatsSelectors.getMatchesByPlayerName(state, playerId ? playerId : "")
     );
     matches.sort((a: Match, b: Match) => Number(b.id) - Number(a.id));
 
@@ -80,7 +80,7 @@ export const PlayerDetails = React.memo(function PlayerDetails() {
     return (
         <Flex direction="column" justify="center" align="center">
             <PlayerDetailsInfoCard playerId={playerId} />
-            <DatePicker onChange={onDatePickerChange} />
+            <DatePicker />
             <Select
                 marginTop={"16px"}
                 display={{ base: "inline", md: "none" }}

--- a/src/redux/stats/statsActions.ts
+++ b/src/redux/stats/statsActions.ts
@@ -2,12 +2,15 @@ import { createAction } from "@reduxjs/toolkit";
 import { Match } from "../../types/domain/Match";
 
 export enum StatsActionType {
-    HydrateMatchHistoryComplete = "StatsActions/HydrateMatchHistoryComplete"
+    HydrateMatchHistoryComplete = "StatsActions/HydrateMatchHistoryComplete",
+    UpdateStartDate = "StatsActions/UpdateStartDate"
 }
 
 export const StatsAction = {
     HydrateMatchHistoryComplete: createAction(StatsActionType.HydrateMatchHistoryComplete, (data: Match[]) => ({
         type: StatsActionType.HydrateMatchHistoryComplete,
         payload: data
-    }))
+    })),
+
+    UpdateStartDate: createAction<string | undefined>(StatsActionType.UpdateStartDate)
 };

--- a/src/redux/stats/statsReducer.ts
+++ b/src/redux/stats/statsReducer.ts
@@ -23,12 +23,18 @@ export type StatsState = Readonly<{
      * A map of all the players where the ID is the user name.
      */
     players: { [id: string]: Player } | undefined;
+
+    /**
+     * The start date for filtering matches (ISO date string)
+     */
+    startDate: string | undefined;
 }>;
 
 const initialState: StatsState = {
     matches: undefined,
     commanders: undefined,
-    players: undefined
+    players: undefined,
+    startDate: undefined
 };
 
 export const statsReducer = createReducer(initialState, (builder) => {
@@ -37,5 +43,9 @@ export const statsReducer = createReducer(initialState, (builder) => {
         state.matches = matchesCollection;
         state.commanders = matchesToCommanderHelper(matchesCollection);
         state.players = matchesToPlayersHelper(matchesCollection);
+    });
+
+    builder.addCase(StatsAction.UpdateStartDate, (state, action) => {
+        state.startDate = action.payload;
     });
 });


### PR DESCRIPTION
This change makes the "match data start date" based on a redux store, such that when you change the date picker value, it stays consistent across all date pickers (and any data that uses the date picker). 

This does not yet migrate all data UI views to use the start date, but sets us forward in that direction. 