### PR TITLE
Migrate local copy of commanders map to chatterfang service based one

### DIFF
--- a/src/components/commanderOverview/CommanderDetails.tsx
+++ b/src/components/commanderOverview/CommanderDetails.tsx
@@ -1,5 +1,3 @@
-// CommanderDetails.tsx
-
 import { TooltipItem } from "chart.js";
 import React, { useCallback, useState } from "react";
 import { useSelector } from "react-redux";
@@ -25,10 +23,10 @@ import {
 
 import { AppState } from "../../redux/rootReducer";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 import { Loading } from "../Loading";
-import { commanderList } from "../../services/commanderList";
 import { SortableTable } from "../dataVisualizations/SortableTable";
-import { matchHistoryColumns } from "../dataVisualizations/columnHelpers/matchHistoryColumnHelper";
+import { getMatchHistoryColumns } from "../dataVisualizations/columnHelpers/matchHistoryColumnHelper";
 import { Match } from "../../types/domain/Match";
 import { MatchPlayer } from "../../types/domain/MatchPlayer";
 import { LineGraph } from "../dataVisualizations/LineGraph";
@@ -50,6 +48,10 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
     const navigate = useNavigate();
     const commanderId = useLoaderData() as string;
     const commander = useSelector((state: AppState) => StatsSelectors.getCommander(state, commanderId));
+    const commanderInfo = useSelector((state: AppState) =>
+        CommandersSelectors.getCommanderByName(state, commander?.name ?? "")
+    );
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     const [showCommanderMatchups, setShowCommanderMatchups] = useState<boolean>(false);
     const [tabIndex, setTabIndex] = useState(0);
@@ -129,6 +131,8 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
         return `Winrate: ${item.formattedValue}%`;
     };
 
+    const matchHistoryColumns = getMatchHistoryColumns(commandersData);
+
     return (
         <Flex direction="column" justifyContent="center" alignItems="center">
             <Flex
@@ -140,10 +144,10 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                 flexWrap="wrap"
                 marginBottom="32px"
             >
-                {commanderList[commander.name] ? (
+                {commanderInfo ? (
                     <Image
                         width="300px"
-                        src={commanderList[commander.name].image}
+                        src={commanderInfo.image}
                         boxShadow="0px 12px 18px 2px rgba(0,0,0,0.3)"
                         borderRadius="4%"
                         zIndex={1}
@@ -189,13 +193,13 @@ export const CommanderDetails = React.memo(function CommanderDetails() {
                     <Text padding="8px 16px" borderLeftWidth="1px" borderRightWidth="1px" borderBottomWidth="1px">
                         {`Qualified: ${commander.validMatchesCount >= COMMANDER_MINIMUM_GAMES_REQUIRED ? "Yes" : "No"}`}
                     </Text>
-                    {commanderList[commander.name] && (
+                    {commanderInfo && (
                         <Link
                             padding="8px 16px"
                             borderLeftWidth="1px"
                             borderRightWidth="1px"
                             borderBottomWidth="1px"
-                            href={commanderList[commander.name].scryfallUri}
+                            href={commanderInfo.scryfallUri}
                             isExternal
                         >
                             View on Scryfall <ExternalLinkIcon marginLeft="4px" marginBottom="5px" />

--- a/src/components/commanderOverview/CommanderMatchupsTable.tsx
+++ b/src/components/commanderOverview/CommanderMatchupsTable.tsx
@@ -5,11 +5,11 @@ import { useNavigate } from "react-router-dom";
 import { SortableTable } from "../dataVisualizations/SortableTable";
 import { AppState } from "../../redux/rootReducer";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 import {
     CommanderMatchupItem,
-    commanderMatchupsColumns
+    getCommanderMatchupsColumns
 } from "../dataVisualizations/columnHelpers/commanderMatchupsColumnHelper";
-import { commanderList } from "../../services/commanderList";
 import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
 import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../constants";
 
@@ -19,6 +19,8 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
     commanderName: string;
 }) {
     const navigate = useNavigate();
+
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     // get all the valid matches the commander has participated in
     const matches = filterMatchesByPlayerCount(
@@ -45,11 +47,12 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
                 // skip that since we don't want their record against themself
                 if (commander !== commanderName) {
                     const potentialCommander = commanderMatchups[commander];
+                    const commanderDataForThisCommander = commandersData ? commandersData[commander] : undefined;
                     // check to see if the commander already exists in our dictionary. if it doesn't, add it.
                     const commanderMatchup =
                         potentialCommander === undefined
                             ? {
-                                  id: commanderList[commander].id,
+                                  id: commanderDataForThisCommander ? commanderDataForThisCommander.scryfallId : "",
                                   name: commander,
                                   matchCount: 1,
                                   winCount: 0
@@ -68,10 +71,11 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
     }
 
     const commanderMatchupsArray = Object.values(commanderMatchups).sort((a, b) => b.matchCount - a.matchCount);
+    const columns = getCommanderMatchupsColumns(commandersData);
 
     return (
         <SortableTable
-            columns={commanderMatchupsColumns}
+            columns={columns}
             data={commanderMatchupsArray}
             getRowProps={(row: any) => {
                 return {

--- a/src/components/commanderOverview/CommanderOverview.tsx
+++ b/src/components/commanderOverview/CommanderOverview.tsx
@@ -5,8 +5,9 @@ import { useNavigate } from "react-router-dom";
 import { Box, Checkbox, Flex, Input, Tooltip } from "@chakra-ui/react";
 
 import { SortableTable } from "../dataVisualizations/SortableTable";
-import { commanderOverviewColumns } from "../dataVisualizations/columnHelpers/commanderOverviewColumnHelper";
+import { getCommanderOverviewColumns } from "../dataVisualizations/columnHelpers/commanderOverviewColumnHelper";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 import { Loading } from "../Loading";
 import { Commander } from "../../types/domain/Commander";
 import { COMMANDER_MINIMUM_GAMES_REQUIRED } from "../constants";
@@ -17,6 +18,7 @@ export const CommanderOverview = React.memo(function MatchHistory() {
     const navigate = useNavigate();
 
     const allCommanders = useSelector(StatsSelectors.getCommanders);
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
     const { showOnlyQualfied, searchInput, onShowOnlyQualifiedChange, onSearchChange } = useTableFilters();
 
     const commanders: Commander[] = useSelector((state: AppState) => StatsSelectors.getCommandersByDate(state));
@@ -36,6 +38,8 @@ export const CommanderOverview = React.memo(function MatchHistory() {
             allCommanders[value.id].name.toLowerCase().includes(searchInput.toLowerCase())
         );
     }
+
+    const columns = getCommanderOverviewColumns(commandersData);
 
     return (
         <Flex direction="column" justify="center" align="center">
@@ -63,7 +67,7 @@ export const CommanderOverview = React.memo(function MatchHistory() {
             </Flex>
             {commandersArray.length > 0 ? (
                 <SortableTable
-                    columns={commanderOverviewColumns}
+                    columns={columns}
                     data={commandersArray}
                     getRowProps={(row: any) => {
                         return {

--- a/src/components/commanderTrends/CommandersPlayedChart.tsx
+++ b/src/components/commanderTrends/CommandersPlayedChart.tsx
@@ -27,8 +27,6 @@ export const CommandersPlayedChart = React.memo(function CommandersPlayedChart()
         return { x: Number(match.id) + 1, y: Object.keys(commandersDictionary).length };
     });
 
-    console.log(commandersCountData);
-
     const tooltipTitleCallback = (item: TooltipItem<"line">[]) => {
         return `Match Id: ${matches[item[0].dataIndex].id}`;
     };

--- a/src/components/dataVisualizations/columnHelpers/commanderMatchupsColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderMatchupsColumnHelper.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Image } from "@chakra-ui/react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { getWinRatePercentage } from "../../../logic/utils";
-import { commanderList } from "../../../services/commanderList";
+import { CommanderData } from "../../../services/CommanderService";
 
 export type CommanderMatchupItem = {
     id: string;
@@ -12,13 +12,16 @@ export type CommanderMatchupItem = {
 
 const columnHelper = createColumnHelper<CommanderMatchupItem>();
 
-export const commanderMatchupsColumns: ColumnDef<CommanderMatchupItem, any>[] = [
+export const getCommanderMatchupsColumns = (
+    commandersMap: { [name: string]: CommanderData } | undefined
+): ColumnDef<CommanderMatchupItem, any>[] => [
     columnHelper.accessor((row) => row.name, {
         id: "name",
         cell: (info) => {
             const commander = info.getValue();
-            const commanderImage = commanderList[commander]
-                ? commanderList[commander].image.replace("normal", "art_crop")
+            const commanderData = commandersMap ? commandersMap[commander] : undefined;
+            const commanderImage = commanderData
+                ? commanderData.image.replace("normal", "art_crop")
                 : "";
 
             return (
@@ -49,3 +52,6 @@ export const commanderMatchupsColumns: ColumnDef<CommanderMatchupItem, any>[] = 
         header: () => <span>Winrate Against</span>
     })
 ];
+
+// Keep the old export for backward compatibility
+export const commanderMatchupsColumns: ColumnDef<CommanderMatchupItem, any>[] = getCommanderMatchupsColumns(undefined);

--- a/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/commanderOverviewColumnHelper.tsx
@@ -1,18 +1,21 @@
 import { Box, Flex, Image } from "@chakra-ui/react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { getWinRatePercentage } from "../../../logic/utils";
-import { commanderList } from "../../../services/commanderList";
+import { CommanderData } from "../../../services/CommanderService";
 import { Commander } from "../../../types/domain/Commander";
 
 const columnHelper = createColumnHelper<Commander>();
 
-export const commanderOverviewColumns: ColumnDef<Commander, any>[] = [
+export const getCommanderOverviewColumns = (
+    commandersMap: { [name: string]: CommanderData } | undefined
+): ColumnDef<Commander, any>[] => [
     columnHelper.accessor((row) => row.name, {
         id: "name",
         cell: (info) => {
             const commander = info.getValue();
-            const commanderImage = commanderList[commander]
-                ? commanderList[commander].image.replace("normal", "art_crop")
+            const commanderData = commandersMap ? commandersMap[commander] : undefined;
+            const commanderImage = commanderData
+                ? commanderData.image.replace("normal", "art_crop")
                 : "";
 
             return (
@@ -46,3 +49,6 @@ export const commanderOverviewColumns: ColumnDef<Commander, any>[] = [
         }
     )
 ];
+
+// Keep the old export for backward compatibility, but use undefined for now
+export const commanderOverviewColumns: ColumnDef<Commander, any>[] = getCommanderOverviewColumns(undefined);

--- a/src/components/dataVisualizations/columnHelpers/matchHistoryColumnHelper.tsx
+++ b/src/components/dataVisualizations/columnHelpers/matchHistoryColumnHelper.tsx
@@ -4,13 +4,15 @@ import { Flex, Image, Tag, TagLabel, TagRightIcon, Text } from "@chakra-ui/react
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 
 import { Match } from "../../../types/domain/Match";
-import { commanderList } from "../../../services/commanderList";
+import { CommanderData } from "../../../services/CommanderService";
 import { primaryColor } from "../../../themes/acorn";
 import { MatchTag, getMatchTags } from "../../../logic/matchTags";
 
 const columnHelper = createColumnHelper<Match>();
 
-export const matchHistoryColumns: ColumnDef<Match, any>[] = [
+export const getMatchHistoryColumns = (
+    commandersMap: { [name: string]: CommanderData } | undefined
+): ColumnDef<Match, any>[] => [
     columnHelper.accessor((row) => row.id, {
         id: "id",
         cell: (info) => info.getValue(),
@@ -71,8 +73,9 @@ export const matchHistoryColumns: ColumnDef<Match, any>[] = [
             // get the commander image for the winner
             const winner = match.players.find((player) => player.name === match.winner);
             const commander = winner ? winner.commanders[0] : "";
-            const commanderImage = commanderList[commander]
-                ? commanderList[commander].image.replace("normal", "art_crop")
+            const commanderData = commandersMap ? commandersMap[commander] : undefined;
+            const commanderImage = commanderData
+                ? commanderData.image.replace("normal", "art_crop")
                 : "";
 
             return (
@@ -92,3 +95,6 @@ export const matchHistoryColumns: ColumnDef<Match, any>[] = [
         header: () => <span>Turn Count</span>
     })
 ];
+
+// Keep the old export for backward compatibility
+export const matchHistoryColumns: ColumnDef<Match, any>[] = getMatchHistoryColumns(undefined);

--- a/src/components/matchHistory/MatchDetails.tsx
+++ b/src/components/matchHistory/MatchDetails.tsx
@@ -5,8 +5,8 @@ import { Flex, Heading, Tag, TagLabel, TagRightIcon, Text } from "@chakra-ui/rea
 import { AppState } from "../../redux/rootReducer";
 import { useSelector } from "react-redux";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 import { Loading } from "../Loading";
-import { commanderList } from "../../services/commanderList";
 import { MatchDisplayPlayer } from "./types/MatchDisplayPlayer";
 import { MatchPlayerCard } from "./MatchPlayerCard";
 import { rankDictionary } from "../constants";
@@ -24,6 +24,7 @@ export const MatchDetails = React.memo(function MatchDetails() {
 
     // look up this matchId in the matchHistory
     const match = useSelector((state: AppState) => StatsSelectors.getMatch(state, matchId));
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     if (match === undefined) {
         return <Loading text="" />;
@@ -36,9 +37,10 @@ export const MatchDetails = React.memo(function MatchDetails() {
             name: player.name,
             rank: rankDictionary[player.rank],
             commanders: player.commanders.map((commanderName: string) => {
+                const commanderData = commandersData ? commandersData[commanderName] : undefined;
                 return {
                     name: commanderName,
-                    id: commanderList[commanderName] ? commanderList[commanderName].id : undefined
+                    id: commanderData ? commanderData.scryfallId : undefined
                 };
             }),
             isWinner: match.winner === player.name

--- a/src/components/matchHistory/MatchHistory.tsx
+++ b/src/components/matchHistory/MatchHistory.tsx
@@ -1,16 +1,19 @@
 import { Flex } from "@chakra-ui/react";
 import React from "react";
 import { SortableTable } from "../dataVisualizations/SortableTable";
-import { matchHistoryColumns } from "../dataVisualizations/columnHelpers/matchHistoryColumnHelper";
+import { getMatchHistoryColumns } from "../dataVisualizations/columnHelpers/matchHistoryColumnHelper";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 import { useSelector } from "react-redux";
 import { Loading } from "../Loading";
 import { useNavigate } from "react-router-dom";
 import { Match } from "../../types/domain/Match";
+import { AppState } from "../../redux/rootReducer";
 
 export const MatchHistory = React.memo(function MatchHistory() {
     const navigate = useNavigate();
     let matches = useSelector(StatsSelectors.getMatches);
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     if (matches === undefined) {
         return <Loading text="" />;
@@ -18,11 +21,12 @@ export const MatchHistory = React.memo(function MatchHistory() {
 
     // Cannot directly mutate state, copy to new array first
     matches = matches.slice().sort((a: Match, b: Match) => Number(b.id) - Number(a.id));
+    const columns = getMatchHistoryColumns(commandersData);
 
     return (
         <Flex direction="column" justify="center" align="center">
             <SortableTable
-                columns={matchHistoryColumns}
+                columns={columns}
                 data={matches}
                 getRowProps={(row: any) => {
                     return {

--- a/src/components/matchHistory/MatchPlayerImage.tsx
+++ b/src/components/matchHistory/MatchPlayerImage.tsx
@@ -12,8 +12,10 @@ import {
     useDisclosure
 } from "@chakra-ui/react";
 import React, { useCallback } from "react";
+import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { commanderList } from "../../services/commanderList";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
+import { AppState } from "../../redux/rootReducer";
 import { MatchDisplayPlayer } from "./types/MatchDisplayPlayer";
 import { MatchDisplayCommander } from "./types/MatchDisplayCommander";
 
@@ -21,6 +23,7 @@ export const MatchPlayerImage = React.memo(function MatchPlayerImage({ player }:
     const navigate = useNavigate();
     const { isOpen, onOpen, onClose } = useDisclosure();
     const finalRef = React.useRef(null);
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     const soloCommanderNav = useCallback(() => {
         if (player.commanders[0].id !== undefined) {
@@ -39,6 +42,8 @@ export const MatchPlayerImage = React.memo(function MatchPlayerImage({ player }:
             }
         };
 
+        const commanderData = commandersData ? commandersData[value.name] : undefined;
+
         return (
             <Button
                 key={value.id}
@@ -50,10 +55,10 @@ export const MatchPlayerImage = React.memo(function MatchPlayerImage({ player }:
                 size={"lg"}
                 alignSelf={"stretch"}
             >
-                {commanderList[value.name] ? (
+                {commanderData ? (
                     <Image
                         key={value.id}
-                        src={commanderList[value.name].image}
+                        src={commanderData.image}
                         borderRadius={"4%"}
                         boxShadow={"0px 12px 18px 2px rgba(0,0,0,0.3)"}
                     />
@@ -87,10 +92,10 @@ export const MatchPlayerImage = React.memo(function MatchPlayerImage({ player }:
                 height={"300px"}
                 size="md"
             >
-                {commanderList[player.commanders[0].name] ? (
+                {commandersData?.[player.commanders[0].name] ? (
                     <Image
                         height={player.isWinner ? "100%" : "85%"}
-                        src={commanderList[player.commanders[0].name].image}
+                        src={commandersData[player.commanders[0].name].image}
                         borderRadius={"4%"}
                         boxShadow={"0px 12px 18px 2px rgba(0,0,0,0.3)"}
                     />
@@ -124,9 +129,9 @@ export const MatchPlayerImage = React.memo(function MatchPlayerImage({ player }:
                 >
                     <div style={{ display: "grid" }}>
                         <div style={{ gridRowStart: 1, gridColumnStart: 1 }}>
-                            {commanderList[player.commanders[1].name] ? (
+                            {commandersData?.[player.commanders[1].name] ? (
                                 <Image
-                                    src={commanderList[player.commanders[1].name].image}
+                                    src={commandersData[player.commanders[1].name].image}
                                     borderRadius={"4%"}
                                     boxShadow={"0px 12px 18px 2px rgba(0,0,0,0.3)"}
                                 />
@@ -146,9 +151,9 @@ export const MatchPlayerImage = React.memo(function MatchPlayerImage({ player }:
                             )}
                         </div>
                         <div style={{ gridRowStart: 1, gridColumnStart: 1, paddingTop: "20%" }}>
-                            {commanderList[player.commanders[0].name] ? (
+                            {commandersData?.[player.commanders[0].name] ? (
                                 <Image
-                                    src={commanderList[player.commanders[0].name].image}
+                                    src={commandersData[player.commanders[0].name].image}
                                     borderRadius={"4%"}
                                     boxShadow={"0px 12px 18px 2px rgba(0,0,0,0.3)"}
                                 />
@@ -169,9 +174,9 @@ export const MatchPlayerImage = React.memo(function MatchPlayerImage({ player }:
                         </div>
                         {player.commanders[2] !== undefined ? (
                             <div style={{ gridRowStart: 1, gridColumnStart: 1, paddingTop: "90%" }}>
-                                {commanderList[player.commanders[2].name] ? (
+                                {commandersData?.[player.commanders[2].name] ? (
                                     <Image
-                                        src={commanderList[player.commanders[2].name].image}
+                                        src={commandersData[player.commanders[2].name].image}
                                         width={"50%"}
                                         borderRadius={"4%"}
                                         boxShadow={"0px 12px 18px 2px rgba(0,0,0,0.3)"}

--- a/src/components/matchHistory/MatchSubmission.tsx
+++ b/src/components/matchHistory/MatchSubmission.tsx
@@ -25,7 +25,8 @@ import { TriangleDownIcon, TriangleUpIcon } from "@chakra-ui/icons";
 
 import { MatchHistoryService } from "../../services/MatchHistoryService";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
-import { commanderList } from "../../services/commanderList";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
+import { AppState } from "../../redux/rootReducer";
 
 const placeholderImage = "https://static.thenounproject.com/png/5425-200.png";
 
@@ -114,8 +115,9 @@ const MatchSubmissionPlayerCard = React.memo(function MatchSubmissionPlayerCard(
         [setPlayerRank]
     );
 
-    const commanderImage = commanderList[commanderSelectValue]
-        ? commanderList[commanderSelectValue].image.replace("normal", "art_crop")
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
+    const commanderImage = commandersData?.[commanderSelectValue]
+        ? commandersData[commanderSelectValue].image.replace("normal", "art_crop")
         : undefined;
 
     return (
@@ -351,12 +353,14 @@ export const MatchSubmission = React.memo(function MatchSubmission() {
     ]);
 
     // loop through all of players and create their matchSubmission cards
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     const commandersArray = useMemo(() => {
-        return Object.keys(commanderList).map((value) => {
+        const commanders = commandersData || {};
+        return Object.keys(commanders).map((value) => {
             return { name: value, label: value };
         });
-    }, []);
+    }, [commandersData]);
 
     return (
         <Flex direction="column" justify="center" align="center">

--- a/src/components/playerOverview/CommanderHistoryTable.tsx
+++ b/src/components/playerOverview/CommanderHistoryTable.tsx
@@ -5,8 +5,9 @@ import { useNavigate } from "react-router-dom";
 import { AppState } from "../../redux/rootReducer";
 import { Commander } from "../../types/domain/Commander";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 import { SortableTable } from "../dataVisualizations/SortableTable";
-import { commanderOverviewColumns } from "../dataVisualizations/columnHelpers/commanderOverviewColumnHelper";
+import { getCommanderOverviewColumns } from "../dataVisualizations/columnHelpers/commanderOverviewColumnHelper";
 
 export const CommanderHistoryTable = React.memo(function CommanderHistoryTable({ playerId }: { playerId: string }) {
     const navigate = useNavigate();
@@ -17,9 +18,12 @@ export const CommanderHistoryTable = React.memo(function CommanderHistoryTable({
     );
     playedCommanders.sort((a: Commander, b: Commander) => b.validMatchesCount - a.validMatchesCount);
 
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
+    const columns = getCommanderOverviewColumns(commandersData);
+
     return (
         <SortableTable
-            columns={commanderOverviewColumns}
+            columns={columns}
             data={playedCommanders}
             getRowProps={(row: any) => {
                 return {

--- a/src/components/playerOverview/CommanderMatchupsTable.tsx
+++ b/src/components/playerOverview/CommanderMatchupsTable.tsx
@@ -5,11 +5,11 @@ import { useNavigate } from "react-router-dom";
 import { SortableTable } from "../dataVisualizations/SortableTable";
 import { AppState } from "../../redux/rootReducer";
 import { StatsSelectors } from "../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 import {
     CommanderMatchupItem,
-    commanderMatchupsColumns
+    getCommanderMatchupsColumns
 } from "../dataVisualizations/columnHelpers/commanderMatchupsColumnHelper";
-import { commanderList } from "../../services/commanderList";
 import { filterMatchesByPlayerCount } from "../../logic/dictionaryUtils";
 import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../constants";
 
@@ -21,6 +21,8 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
     dateFilter?: Date;
 }) {
     const navigate = useNavigate();
+
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     // get all the valid matches the player has participated in
     const matches = filterMatchesByPlayerCount(
@@ -37,11 +39,12 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
                 // if this is the player that we are getting matchups for, skip that since we don't want their record against themself
                 if (player.name !== playerId) {
                     const potentialCommander = commanderMatchups[commander];
+                    const commanderDataForThisCommander = commandersData ? commandersData[commander] : undefined;
                     // check to see if the commander already exists in our dictionary. if it doesn't, add it.
                     const commanderMatchup =
                         potentialCommander === undefined
                             ? {
-                                  id: commanderList[commander].id,
+                                  id: commanderDataForThisCommander ? commanderDataForThisCommander.scryfallId : "",
                                   name: commander,
                                   matchCount: 1,
                                   winCount: 0
@@ -60,10 +63,11 @@ export const CommanderMatchupsTable = React.memo(function CommanderMatchupsTable
     }
 
     const commanderMatchupsArray = Object.values(commanderMatchups).sort((a, b) => b.matchCount - a.matchCount);
+    const columns = getCommanderMatchupsColumns(commandersData);
 
     return (
         <SortableTable
-            columns={commanderMatchupsColumns}
+            columns={columns}
             data={commanderMatchupsArray}
             getRowProps={(row: any) => {
                 return {

--- a/src/components/playerOverview/playerDetails/PlayerDecks.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDecks.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { AppState } from "../../../redux/rootReducer";
 import { ProfileSelectors } from "../../../redux/profiles/profilesSelectors";
+import { CommandersSelectors } from "../../../redux/commanders/commandersSelectors";
 import { Button, Flex, Image } from "@chakra-ui/react";
-import { commanderList } from "../../../services/commanderList";
 import { DeckSource } from "../../../types/domain/DeckSource";
 import { ExternalDeck } from "../../../types/domain/ExternalDeck";
 
@@ -13,6 +13,7 @@ export const PlayerDecks = React.memo(function PlayerDecks({ profileId }: { prof
     const profile = useSelector((state: AppState) => ProfileSelectors.getProfile(state, profileId ?? ""));
     const moxfieldDecks = useSelector(ProfileSelectors.getMoxfieldDecks);
     const archidektDecks = useSelector(ProfileSelectors.getArchidektDecks);
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     // this component will not render unless moxfield decks are populated
     if (profile === undefined) {
@@ -32,7 +33,8 @@ export const PlayerDecks = React.memo(function PlayerDecks({ profileId }: { prof
                     const result = moxfieldDecks[curDeck.externalId.id];
                     if (result !== undefined) {
                         deck = result;
-                        commanderImageUri = commanderList[result.commanderName]?.image.replace("normal", "art_crop");
+                        const commanderData = commandersData ? commandersData[result.commanderName] : undefined;
+                        commanderImageUri = commanderData?.image.replace("normal", "art_crop");
                     }
                 }
                 break;

--- a/src/components/playerOverview/playerDetails/PlayerDetails.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetails.tsx
@@ -17,8 +17,9 @@ import {
 } from "@chakra-ui/react";
 
 import { StatsSelectors } from "../../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../../redux/commanders/commandersSelectors";
 import { AppState } from "../../../redux/rootReducer";
-import { matchHistoryColumns } from "../../dataVisualizations/columnHelpers/matchHistoryColumnHelper";
+import { getMatchHistoryColumns } from "../../dataVisualizations/columnHelpers/matchHistoryColumnHelper";
 import { SortableTable } from "../../dataVisualizations/SortableTable";
 import { Loading } from "../../Loading";
 import { MatchPlacementBarChart } from "../MatchPlacementBarChart";
@@ -46,6 +47,7 @@ export const PlayerDetails = React.memo(function PlayerDetails() {
     const profileId = toskiToDiscordMap && player ? toskiToDiscordMap[player.name.toLowerCase()] : undefined;
     const profile = useSelector((state: AppState) => ProfileSelectors.getProfile(state, profileId ?? ""));
     const commanders = useSelector((state: AppState) => StatsSelectors.getCommanders(state));
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     const [showCommanderMatchups, setShowCommanderMatchups] = useState<boolean>(false);
     const [tabIndex, setTabIndex] = useState(0);
@@ -69,6 +71,8 @@ export const PlayerDetails = React.memo(function PlayerDetails() {
     if (commanders === undefined || player === undefined) {
         return <Loading text="Loading..." />;
     }
+
+    const matchHistoryColumns = getMatchHistoryColumns(commandersData);
 
     return (
         <Flex direction="column" justify="center" align="center">

--- a/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
@@ -4,12 +4,12 @@ import { useSelector } from "react-redux";
 import { Flex, Heading, Text } from "@chakra-ui/react";
 
 import { StatsSelectors } from "../../../redux/stats/statsSelectors";
+import { CommandersSelectors } from "../../../redux/commanders/commandersSelectors";
 import { AppState } from "../../../redux/rootReducer";
 import { MTG_COLORS } from "../../constants";
 import { ImageWithHover } from "../../common/ImageWithHover";
 import { PieGraph } from "../../dataVisualizations/PieGraph";
 import { getAverageWinTurnForPlayer, getWinRatePercentage } from "../../../logic/utils";
-import { commanderList } from "../../../services/commanderList";
 import { primaryColor } from "../../../themes/acorn";
 import { ProfileSelectors } from "../../../redux/profiles/profilesSelectors";
 import { ExternalProfile } from "../../../types/domain/ExternalProfile";
@@ -25,6 +25,7 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
     const favoriteCommander = useSelector((state: AppState) =>
         StatsSelectors.getFavoriteCommanderForPlayer(state, playerId)
     );
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     const toskiToDiscordMap = useSelector((state: AppState) => state.profiles.toskiToDiscordMap);
 
@@ -74,13 +75,14 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
     }
 
     const favoriteCommanderId = profile && profile.favoriteCommanderId ? profile.favoriteCommanderId : "";
-    const themeCommander = Object.values(commanderList).find((value) => value.id === favoriteCommanderId);
+    const themeCommander = commandersData ? Object.values(commandersData).find((value) => value.scryfallId === favoriteCommanderId) : undefined;
     const themeCommanderImage = themeCommander?.image.replace("normal", "art_crop");
     const themeCommanderName = themeCommander?.name;
 
     // if the user has selected a favorite commander, use that, otherwise, default to their most played commander
+    const favCommanderData = favoriteCommander && commandersData ? commandersData[favoriteCommander.name] : undefined;
     const favCommanderImage = favoriteCommander
-        ? themeCommanderImage ?? commanderList[favoriteCommander.name].image.replace("normal", "art_crop")
+        ? themeCommanderImage ?? favCommanderData?.image.replace("normal", "art_crop")
         : "";
     const favCommanderName = themeCommanderName ?? favoriteCommander?.name;
 

--- a/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
+++ b/src/components/playerOverview/playerDetails/PlayerDetailsInfoCard.tsx
@@ -75,7 +75,9 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
     }
 
     const favoriteCommanderId = profile && profile.favoriteCommanderId ? profile.favoriteCommanderId : "";
-    const themeCommander = commandersData ? Object.values(commandersData).find((value) => value.scryfallId === favoriteCommanderId) : undefined;
+    const themeCommander = commandersData
+        ? Object.values(commandersData).find((value) => value.scryfallId === favoriteCommanderId)
+        : undefined;
     const themeCommanderImage = themeCommander?.image.replace("normal", "art_crop");
     const themeCommanderName = themeCommander?.name;
 
@@ -96,7 +98,7 @@ export const PlayerDetailsInfoCard = React.memo(function PlayerDetailsInfoCard({
 
     return (
         <Flex direction="row" justifyContent="center" alignItems={"center"} flexWrap={"wrap"} marginBottom={"16px"}>
-            {favoriteCommander ? (
+            {favoriteCommander && favCommanderImage ? (
                 <ImageWithHover
                     label={`Favorite Commander: ${favCommanderName}`}
                     width={300}

--- a/src/components/settings/FavoriteCommanderSection.tsx
+++ b/src/components/settings/FavoriteCommanderSection.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useMemo } from "react";
 
 import { Flex, Select, Text, Image } from "@chakra-ui/react";
-
-import { commanderList } from "../../services/commanderList";
+import { useSelector } from "react-redux";
+import { AppState } from "../../redux/rootReducer";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 
 const placeholderImage = "https://static.thenounproject.com/png/5425-200.png";
 
@@ -13,17 +14,21 @@ export const FavoriteCommanderSection = React.memo(function FavoriteCommanderSec
     favoriteCommander: string;
     setFavoriteCommander: (value: string) => void;
 }) {
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
+
     const commandersArray = useMemo(() => {
-        return Object.keys(commanderList).map((commanderName) => {
-            return { id: commanderList[commanderName].id, name: commanderName };
+        if (!commandersData) return [];
+        return Object.values(commandersData).map((commander) => {
+            return { id: commander.scryfallId, name: commander.name };
         });
-    }, []);
+    }, [commandersData]);
 
     const commanderImage = useMemo(() => {
-        return Object.values(commanderList)
-            .find((commander) => commander.id === favoriteCommander)
+        if (!commandersData) return undefined;
+        return Object.values(commandersData)
+            .find((commander) => commander.scryfallId === favoriteCommander)
             ?.image.replace("normal", "art_crop");
-    }, [favoriteCommander]);
+    }, [favoriteCommander, commandersData]);
 
     const onCommanderSelectChange = useCallback(
         (event: any) => {

--- a/src/components/settings/FavoriteDecksSection.tsx
+++ b/src/components/settings/FavoriteDecksSection.tsx
@@ -5,8 +5,8 @@ import { Button, Flex, Image, Input } from "@chakra-ui/react";
 
 import { useUserInfo } from "../../logic/hooks/userHooks";
 import { ProfileSelectors } from "../../redux/profiles/profilesSelectors";
+import { CommandersSelectors } from "../../redux/commanders/commandersSelectors";
 import { AppState } from "../../redux/rootReducer";
-import { commanderList } from "../../services/commanderList";
 import { ProfileService } from "../../services/ProfileService";
 
 import { FiTrash2 } from "react-icons/fi";
@@ -74,6 +74,7 @@ export const FavoriteDecksSection = React.memo(function FavoriteDecksSection() {
     const profile = useSelector((state: AppState) => ProfileSelectors.getProfile(state, userId ?? ""));
     const moxfieldDecks = useSelector(ProfileSelectors.getMoxfieldDecks);
     const archidektDecks = useSelector(ProfileSelectors.getArchidektDecks);
+    const commandersData = useSelector((state: AppState) => CommandersSelectors.getCommanders(state));
 
     const [deckUrl, setDeckUrl] = useState<string>();
     const [canAddDeck, setCanAddDeck] = useState<boolean>(true);
@@ -129,10 +130,8 @@ export const FavoriteDecksSection = React.memo(function FavoriteDecksSection() {
                         const result = moxfieldDecks[curDeck.externalId.id];
                         if (result !== undefined) {
                             deck = result;
-                            commanderImageUri = commanderList[result.commanderName]?.image.replace(
-                                "normal",
-                                "art_crop"
-                            );
+                            const commanderData = commandersData ? commandersData[result.commanderName] : undefined;
+                            commanderImageUri = commanderData?.image.replace("normal", "art_crop");
                         }
                     }
                     break;

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -1,9 +1,9 @@
 import { NUMBER_OF_PLAYERS_FOR_VALID_MATCH } from "../components/constants";
-import { commanderList } from "../services/commanderList";
 import { Commander } from "../types/domain/Commander";
 import { Match } from "../types/domain/Match";
 import { Player } from "../types/domain/Player";
 import { getColorIdentity } from "./utils";
+import { CommanderData } from "../services/CommanderService";
 
 /**
  * Given a collection of Matches, filter out games that don't have the desired number of players.
@@ -58,12 +58,14 @@ export function filterMatchesByDate(matches: Match[], startDate?: Date, endDate?
  * (as determined by the required number of players in the match).
  * @param matches The collection of matches to build the dictionary from
  * @param playerId An optional player name to filter the commanders by (will only return commanders the player has played)
+ * @param commandersMap Optional map of commanders to look up color identity. If not provided, empty array is used.
  * @returns A dictionary of commanders keyed by commanderId
  */
 export function matchesToCommanderHelper(
     matches: Match[],
     playerNameFilter?: string,
-    startDate?: Date
+    startDate?: Date,
+    commandersMap?: { [name: string]: CommanderData }
 ): { [id: string]: Commander } {
     const filteredMatches = filterMatchesByDate(matches, startDate);
 
@@ -83,26 +85,21 @@ export function matchesToCommanderHelper(
 
             // loop through all commanders and update our commanders dictionary
             for (const currentCommanderName of currentCommanderNames) {
-                const commander = commanderList[currentCommanderName];
+                const commanderData = commandersMap ? commandersMap[currentCommanderName] : undefined;
 
-                // check to see if the commander name is valid
-                if (commander === undefined) {
-                    // log the invalid commander
-                    console.log(
-                        `Invalid commander found in currentMatch <${currentMatch.id}> : ${currentCommanderName}`
-                    );
-                    continue;
-                }
+                // Use the scryfallId from commanderData if available, otherwise use the name as a fallback
+                const commanderId = commanderData ? commanderData.scryfallId : currentCommanderName;
 
                 // commander name is valid. let's check to see if we already added it to our dictionary
-                const potentialCommanderObj = playedCommanderDictionary[commander.id];
+                const potentialCommanderObj = playedCommanderDictionary[commanderId];
                 if (potentialCommanderObj === undefined) {
                     // the entry doesn't exist, add it to our dictionary
-                    playedCommanderDictionary[commander.id] = {
-                        id: commander.id,
+                    const colorIdentity = commanderData ? commanderData.colorIdentity : [];
+                    playedCommanderDictionary[commanderId] = {
+                        id: commanderId,
                         name: currentCommanderName,
-                        colorIdentity: commander.colorIdentity,
-                        colorIdentityName: getColorIdentity(commander.colorIdentity) ?? "",
+                        colorIdentity: colorIdentity,
+                        colorIdentityName: getColorIdentity(colorIdentity) ?? "",
                         matches: [currentMatch.id],
                         validMatchesCount: currentMatch.players.length === NUMBER_OF_PLAYERS_FOR_VALID_MATCH ? 1 : 0,
                         wins:
@@ -135,7 +132,8 @@ export function matchesToCommanderHelper(
 export function matchesToPlayersHelper(
     matches: Match[],
     commanderNameFilter?: string,
-    startDate?: Date
+    startDate?: Date,
+    commandersMap?: { [name: string]: CommanderData }
 ): { [id: string]: Player } {
     const filteredMatches = filterMatchesByDate(matches, startDate);
 
@@ -165,7 +163,7 @@ export function matchesToPlayersHelper(
 
                     // compute the players color profile
                     for (const commanderName of player.commanders) {
-                        const potentialCommander = commanderList[commanderName];
+                        const potentialCommander = commandersMap ? commandersMap[commanderName] : undefined;
                         const colors = potentialCommander ? potentialCommander.colorIdentity : [];
 
                         for (const color of colors) {
@@ -212,7 +210,7 @@ export function matchesToPlayersHelper(
 
                     // compute the players color profile
                     for (const commanderName of player.commanders) {
-                        const potentialCommander = commanderList[commanderName];
+                        const potentialCommander = commandersMap ? commandersMap[commanderName] : undefined;
                         const colors = potentialCommander ? potentialCommander.colorIdentity : [];
 
                         for (const color of colors) {

--- a/src/logic/dictionaryUtils.ts
+++ b/src/logic/dictionaryUtils.ts
@@ -88,13 +88,14 @@ export function matchesToCommanderHelper(
                 const commanderData = commandersMap ? commandersMap[currentCommanderName] : undefined;
 
                 // Use the scryfallId from commanderData if available, otherwise use the name as a fallback
-                const commanderId = commanderData ? commanderData.scryfallId : currentCommanderName;
+                const commanderId = commanderData ? commanderData.id : currentCommanderName;
+
+                const colorIdentity = commanderData ? commanderData.colorIdentity : [];
 
                 // commander name is valid. let's check to see if we already added it to our dictionary
                 const potentialCommanderObj = playedCommanderDictionary[commanderId];
                 if (potentialCommanderObj === undefined) {
                     // the entry doesn't exist, add it to our dictionary
-                    const colorIdentity = commanderData ? commanderData.colorIdentity : [];
                     playedCommanderDictionary[commanderId] = {
                         id: commanderId,
                         name: currentCommanderName,

--- a/src/navigation/Root.tsx
+++ b/src/navigation/Root.tsx
@@ -6,12 +6,14 @@ import AppFrame from "../components/navigation/AppFrame";
 import { MatchHistoryService } from "../services/MatchHistoryService";
 import { DiscordService } from "../services/DiscordService";
 import { ProfileService } from "../services/ProfileService";
+import { CommanderService } from "../services/CommanderService";
 import { useAuthInfo } from "../logic/hooks/authHooks";
 
 export default function Root() {
     const hydrateProfiles = ProfileService.useHydrateProfiles();
     const getCurrentUserInfo = DiscordService.useGetCurrentUserInfo();
     const getMatchHistory = MatchHistoryService.useMatchHistory();
+    const hydrateCommanders = CommanderService.useHydrateCommanders();
 
     const { accessToken, tokenType } = useAuthInfo();
 
@@ -21,6 +23,9 @@ export default function Root() {
 
         // make the initial call to hydrate profiles
         hydrateProfiles();
+
+        // hydrate commanders data
+        hydrateCommanders();
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/src/redux/commanders/commandersActions.ts
+++ b/src/redux/commanders/commandersActions.ts
@@ -1,0 +1,19 @@
+import { createAction } from "@reduxjs/toolkit";
+import { CommanderData } from "../../services/CommanderService";
+
+export enum CommandersActionType {
+    HydrateCommandersComplete = "CommandersActions/HydrateCommandersComplete",
+    SetLoadingCommanders = "CommandersActions/SetLoadingCommanders"
+}
+
+export const CommandersAction = {
+    HydrateCommandersComplete: createAction(
+        CommandersActionType.HydrateCommandersComplete,
+        (data: CommanderData[]) => ({
+            type: CommandersActionType.HydrateCommandersComplete,
+            payload: data
+        })
+    ),
+
+    SetLoadingCommanders: createAction<boolean>(CommandersActionType.SetLoadingCommanders)
+};

--- a/src/redux/commanders/commandersReducer.ts
+++ b/src/redux/commanders/commandersReducer.ts
@@ -1,0 +1,41 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { CommandersAction } from "./commandersActions";
+import { CommanderData } from "../../services/CommanderService";
+
+/**
+ * State containing all commander data
+ */
+export type CommandersState = Readonly<{
+    /**
+     * A map of all commanders where the key is the commander name (friendly name).
+     */
+    commanders: { [name: string]: CommanderData } | undefined;
+
+    /**
+     * Loading state for commanders data
+     */
+    isLoading: boolean;
+}>;
+
+const initialState: CommandersState = {
+    commanders: undefined,
+    isLoading: true
+};
+
+export const commandersReducer = createReducer(initialState, (builder) => {
+    builder.addCase(CommandersAction.HydrateCommandersComplete, (state, action) => {
+        const commandersArray = action.payload;
+        const commandersMap: { [name: string]: CommanderData } = {};
+
+        commandersArray.forEach((commander) => {
+            commandersMap[commander.name] = commander;
+        });
+
+        state.commanders = commandersMap;
+        state.isLoading = false;
+    });
+
+    builder.addCase(CommandersAction.SetLoadingCommanders, (state, action) => {
+        state.isLoading = action.payload;
+    });
+});

--- a/src/redux/commanders/commandersSelectors.ts
+++ b/src/redux/commanders/commandersSelectors.ts
@@ -1,0 +1,46 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { AppState } from "../rootReducer";
+import { CommanderData } from "../../services/CommanderService";
+
+const getCommanders = (state: AppState) => state.commanders.commanders;
+const getIsLoading = (state: AppState) => state.commanders.isLoading;
+
+/**
+ * Gets a specific commander by name.
+ */
+const getCommanderByName = createSelector(
+    getCommanders,
+    (_state: AppState, commanderName: string) => commanderName,
+    (commanders: { [name: string]: CommanderData } | undefined, commanderName: string) => {
+        return commanders ? commanders[commanderName] : undefined;
+    }
+);
+
+/**
+ * Gets all commanders as an array.
+ */
+const getAllCommanders = createSelector(getCommanders, (commanders: { [name: string]: CommanderData } | undefined) => {
+    return commanders ? Object.values(commanders) : [];
+});
+
+/**
+ * Gets all commander names.
+ */
+const getAllCommanderNames = createSelector(
+    getCommanders,
+    (commanders: { [name: string]: CommanderData } | undefined) => {
+        return commanders ? Object.keys(commanders) : [];
+    }
+);
+
+/**
+ * Gets the loading state of commanders.
+ */
+const getCommandersLoading = createSelector(getIsLoading, (isLoading: boolean) => isLoading);
+
+export const CommandersSelectors = {
+    getCommanderByName,
+    getAllCommanders,
+    getAllCommanderNames,
+    getCommandersLoading
+};

--- a/src/redux/commanders/commandersSelectors.ts
+++ b/src/redux/commanders/commandersSelectors.ts
@@ -42,5 +42,6 @@ export const CommandersSelectors = {
     getCommanderByName,
     getAllCommanders,
     getAllCommanderNames,
-    getCommandersLoading
+    getCommandersLoading,
+    getCommanders
 };

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -3,17 +3,20 @@ import { statsReducer, StatsState } from "./stats/statsReducer";
 import { authReducer, AuthState } from "./auth/authReducer";
 import { userReducer, UserState } from "./user/userReducer";
 import { profilesReducer, ProfilesState } from "./profiles/profilesReducer";
+import { commandersReducer, CommandersState } from "./commanders/commandersReducer";
 
 export interface AppState {
     stats: StatsState;
     auth: AuthState;
     user: UserState;
     profiles: ProfilesState;
+    commanders: CommandersState;
 }
 
 export const rootReducer: Reducer<AppState> = combineReducers({
     stats: statsReducer,
     auth: authReducer,
     user: userReducer,
-    profiles: profilesReducer
+    profiles: profilesReducer,
+    commanders: commandersReducer
 });

--- a/src/services/CommanderService.ts
+++ b/src/services/CommanderService.ts
@@ -1,0 +1,79 @@
+import axios from "axios";
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+import { CommandersAction } from "../redux/commanders/commandersActions";
+
+export type CommanderApiResponse = {
+    _id: string;
+    scryfallId: string;
+    friendlyName: string;
+    image: string;
+    colorIdentity: string[];
+    scryfallUri: string;
+    lastUpdated: string;
+    __v: number;
+};
+
+export type CommanderData = {
+    id: string;
+    scryfallId: string;
+    name: string;
+    image: string;
+    colorIdentity: string[];
+    scryfallUri: string;
+};
+
+const commandersDataEndpoint = "https://chatterfang.onrender.com/commanders";
+
+const mapApiResponseToCommanderData = (apiResponse: CommanderApiResponse): CommanderData => {
+    return {
+        id: apiResponse.scryfallId,
+        scryfallId: apiResponse.scryfallId,
+        name: apiResponse.friendlyName,
+        image: apiResponse.image,
+        colorIdentity: apiResponse.colorIdentity,
+        scryfallUri: apiResponse.scryfallUri
+    };
+};
+
+const useGetCommanders = () => {
+    return useCallback(async (): Promise<CommanderData[] | undefined> => {
+        try {
+            const res = await axios.get<CommanderApiResponse[]>(commandersDataEndpoint, {
+                headers: { "Content-Type": "application/json" }
+            });
+            return res.data.map(mapApiResponseToCommanderData);
+        } catch (err) {
+            console.error("Failed to fetch commanders:", err);
+            return undefined;
+        }
+    }, []);
+};
+
+const useHydrateCommanders = () => {
+    const dispatch = useDispatch();
+    const getCommanders = useGetCommanders();
+
+    return useCallback(async () => {
+        try {
+            dispatch(CommandersAction.SetLoadingCommanders(true));
+            const commanders = await getCommanders();
+
+            if (commanders !== undefined) {
+                dispatch(CommandersAction.HydrateCommandersComplete(commanders));
+            } else {
+                console.error("Failed to hydrate commanders: API returned undefined");
+                dispatch(CommandersAction.SetLoadingCommanders(false));
+            }
+        } catch (err) {
+            console.error("Error hydrating commanders:", err);
+            dispatch(CommandersAction.SetLoadingCommanders(false));
+        }
+    }, [dispatch, getCommanders]);
+};
+
+export const CommanderService = {
+    useGetCommanders,
+    useHydrateCommanders
+};

--- a/src/services/CommanderService.ts
+++ b/src/services/CommanderService.ts
@@ -43,6 +43,7 @@ const useGetCommanders = () => {
             const res = await axios.get<CommanderApiResponse[]>(commandersDataEndpoint, {
                 headers: { "Content-Type": "application/json" }
             });
+
             return res.data.map(mapApiResponseToCommanderData);
         } catch (err) {
             console.error("Failed to fetch commanders:", err);


### PR DESCRIPTION
An extensive PR that moves us away from the hardcoded commanders map to a chatterfang service based commander list. 

While it does mean that the site is dependent on an initial outbound call, it means that we shouldn't need to manually update toski anymore for getting the latest commander list. 